### PR TITLE
fix(linkedin): adapt to LinkedIn DOM changes (Feb 2026)

### DIFF
--- a/linkedin/linkedin-playwright.js
+++ b/linkedin/linkedin-playwright.js
@@ -6,9 +6,11 @@
  *
  * LinkedIn uses obfuscated/hashed CSS class names that change frequently.
  * This connector avoids class names entirely, finding data by:
- *   1. Isolating the content section (main > div > div > div:first-child)
- *   2. Drilling through single-child wrappers to reach entry containers
- *   3. Parsing P element text positionally with content-based heuristics
+ *   1. Isolating the content section (main > div > div > div:first-child,
+ *      with fallback to main section or main)
+ *   2. Walking the DOM tree scoring containers by entry-like children
+ *   3. Extracting text from P elements, falling back to leaf SPAN elements
+ *   4. Parsing text positionally with content-based heuristics
  *
  * Navigates to /details/ subpages to get complete data (experience, skills,
  * education, languages) beyond what's visible on the main profile.
@@ -86,7 +88,7 @@ const navigateToDetailPage = async (baseUrl, section, progressStep, totalSteps, 
     message: `Loading ${section} details page...`,
   });
 
-  await page.goto(detailUrl);
+  await page.goto(detailUrl, { timeout: 60000 });
   await page.sleep(3000);
 
   // Click "Load more" repeatedly until all content is loaded
@@ -143,41 +145,85 @@ const extractHeroSection = async () => {
         const firstSection = document.querySelector('main section');
         if (!firstSection) return data;
 
-        const h2 = firstSection.querySelector('h2');
-        if (h2) data.fullName = h2.textContent.trim();
+        // LinkedIn uses h1 for the name (changed from h2 circa Feb 2026)
+        const heading = firstSection.querySelector('h1') || firstSection.querySelector('h2');
+        if (heading) data.fullName = heading.textContent.trim();
 
         const img = firstSection.querySelector('img');
         if (img && img.src) data.profilePictureUrl = img.src;
 
-        const ps = [];
-        firstSection.querySelectorAll('p').forEach(p => {
-          const t = p.textContent.trim();
-          if (t.length > 1 && t !== '\\u00b7' && t !== '\\u00B7') {
-            ps.push({ text: t, visible: p.offsetHeight > 0 });
+        // LinkedIn moved headline/location/connections out of <p> into <span>/<div>.
+        // Collect visible text snippets, normalizing whitespace and deduplicating.
+        const CTA_PATTERNS = ['connections', 'followers', 'Contact info', 'Open to',
+          'Show details', 'Get started', 'Add titles', 'Tell non-profits', 'Show all',
+          'See all', 'Learn more', 'View profile', 'Message', 'Connect', 'Follow',
+          'Pending', 'More actions', 'Edit', 'Add profile', 'Open', 'premium',
+          'Reactivate', 'Verified', 'Enhance profile', 'Add profile section',
+          'Send profile', 'Save to PDF', 'Saved items', 'Activity', 'Resources',
+          'About this profile'];
+
+        const isCta = (t) => CTA_PATTERNS.some(pat => t.includes(pat));
+        const norm = (s) => s.replace(/\\s+/g, ' ').trim();
+
+        const textNodes = [];
+        const seenTexts = new Set();
+        firstSection.querySelectorAll('p, span, div').forEach(el => {
+          let depth = 0;
+          let par = el.parentElement;
+          while (par && par !== firstSection) { depth++; par = par.parentElement; }
+          if (depth > 8) return;
+
+          const t = norm(el.textContent);
+
+          // Skip wrapper elements: text = concatenation of all children's text
+          if (el.children.length > 0) {
+            const childConcat = norm(Array.from(el.children).map(c => c.textContent).join(''));
+            if (childConcat === t) return;
           }
+
+          if (!t || t.length < 2) return;
+          if (t === '\\u00b7' || t === '\\u00B7') return;
+          if (seenTexts.has(t)) return;
+
+          const visible = el.offsetHeight > 0 && el.offsetWidth > 0;
+          if (!visible) return;
+
+          seenTexts.add(t);
+          textNodes.push({ text: t, tag: el.tagName });
         });
 
-        const visiblePs = ps.filter(p => p.visible);
-        if (visiblePs.length > 0) data.headline = visiblePs[0].text;
-
-        for (const p of visiblePs) {
-          if (p.text.includes('connections') || p.text.includes('followers')) {
-            data.connections = p.text;
+        // Find connections (contains "connections" or "followers")
+        for (const node of textNodes) {
+          if (node.text.includes('connections') || node.text.includes('followers')) {
+            data.connections = node.text;
             break;
           }
         }
 
-        const skipPatterns = ['connections', 'followers', 'Contact info', 'Open to',
-          'Show details', 'Get started', 'Add titles', 'Tell non-profits'];
-        for (let i = 1; i < visiblePs.length; i++) {
-          const t = visiblePs[i].text;
-          if (t === data.headline) continue;
-          if (t === data.connections) break;
-          if (skipPatterns.some(pat => t.includes(pat))) continue;
-          if (t.length < 80) {
-            data.location = t;
-            break;
-          }
+        // Find headline: first non-CTA text that isn't the name
+        for (const node of textNodes) {
+          const t = node.text;
+          if (t === data.fullName) continue;
+          if (t === data.connections) continue;
+          if (isCta(t)) continue;
+          if (t.length > 200) continue;
+          if (t.length < 3) continue;
+          data.headline = t;
+          break;
+        }
+
+        // Find location: next short text after headline
+        let foundHeadline = false;
+        for (const node of textNodes) {
+          const t = node.text;
+          if (t === data.headline) { foundHeadline = true; continue; }
+          if (!foundHeadline) continue;
+          if (t === data.fullName || t === data.connections) continue;
+          if (isCta(t)) continue;
+          if (t.length > 80) continue;
+          if (t.length < 3) continue;
+          data.location = t;
+          break;
         }
 
         return data;
@@ -225,11 +271,14 @@ const extractAboutSection = async () => {
 // ─── Data Extraction: Detail Pages ──────────────────────────
 
 // All detail page extractors share the same container-finding strategy:
-//  1. Isolate content section: main > div > div > div:first-child
-//     (excludes sidebar ads and footer — the root cause of previous mismatches)
+//  1. Isolate content section: try main > div > div > div:first-child first,
+//     fall back to main section, then main (resilient to LinkedIn DOM changes).
 //  2. Walk within content section to find the container with the most
-//     entry-like child divs (divs containing P elements).
-//     This is safe because step 1 already excluded non-content areas.
+//     entry-like child divs/LIs (elements containing P or leaf SPAN text).
+//  3. Extract text preferring <p> elements, falling back to leaf <span>
+//     elements when <p> gives insufficient results. Normalizes whitespace
+//     and skips invisible spans to handle LinkedIn's dual-text pattern
+//     (visible + accessible spans side by side).
 //
 // The shared JS snippet is inlined in each evaluate() call to keep each
 // function self-contained (page.evaluate receives a string, not closures).
@@ -246,29 +295,77 @@ const extractExperiencesFromDetailPage = async () => {
         const HEADINGS = ['Experience', 'Education', 'Skills', 'Languages'];
         const SKIP_TEXT = ['Private to you', 'Visit our', 'Go to your', 'Recommendation transparency'];
 
-        // Find entries container within content section
-        const contentSection = document.querySelector('main > div > div > div:first-child');
+        // Text extraction: prefer <p>, fall back to leaf <span>.
+        // Normalizes whitespace and deduplicates to handle LinkedIn's
+        // dual-text pattern (visible + accessible spans side by side).
+        const norm = (s) => s.replace(/\\s+/g, ' ').trim();
+        const getTexts = (el) => {
+          const seen = new Set();
+          const texts = [];
+          const add = (raw) => {
+            const t = norm(raw);
+            if (!t || t.length < 1 || seen.has(t)) return;
+            seen.add(t);
+            texts.push(t);
+          };
+          el.querySelectorAll('p').forEach(p => add(p.textContent));
+          if (texts.length < 2) {
+            el.querySelectorAll('span').forEach(span => {
+              const raw = span.textContent.trim();
+              if (!raw || raw.length < 2) return;
+              if (span.children.length > 0) {
+                const childConcat = norm(Array.from(span.children).map(c => c.textContent).join(''));
+                if (childConcat === norm(raw)) return;
+              }
+              if (span.offsetHeight === 0 && span.offsetWidth === 0) return;
+              add(raw);
+            });
+          }
+          return texts;
+        };
+
+        // Find content container — try specific selector, fall back to broader
+        const contentSection = document.querySelector('main > div > div > div:first-child')
+          || document.querySelector('main section')
+          || document.querySelector('main');
         if (!contentSection) return experiences;
+
+        const hasEnoughText = (el) => {
+          if (el.querySelectorAll('p').length >= 2) return true;
+          let count = 0;
+          const seen = new Set();
+          el.querySelectorAll('span').forEach(s => {
+            const t = s.textContent.trim();
+            if (t.length < 3 || seen.has(t)) return;
+            if (s.children.length > 0) {
+              const cc = norm(Array.from(s.children).map(c => c.textContent).join(''));
+              if (cc === norm(t)) return;
+            }
+            seen.add(t);
+            count++;
+          });
+          return count >= 2;
+        };
+
         let container = null;
         let bestScore = 0;
         const walk = (el, depth) => {
           if (depth > 15) return;
           let score = 0;
           for (const c of el.children) {
-            if (c.tagName === 'DIV' && c.querySelectorAll('p').length >= 2) score++;
+            if ((c.tagName === 'DIV' || c.tagName === 'LI') && hasEnoughText(c)) score++;
           }
           if (score > bestScore) { bestScore = score; container = el; }
           for (const c of el.children) {
-            if (c.tagName === 'DIV' || c.tagName === 'SECTION') walk(c, depth + 1);
+            if (['DIV', 'SECTION', 'UL', 'LI'].includes(c.tagName)) walk(c, depth + 1);
           }
         };
         walk(contentSection, 0);
         if (!container) return experiences;
 
         for (const child of container.children) {
-          if (child.tagName !== 'DIV') continue;
-          const ps = Array.from(child.querySelectorAll('p'))
-            .map(p => p.textContent.trim()).filter(t => t.length > 0);
+          if (child.tagName !== 'DIV' && child.tagName !== 'LI') continue;
+          const ps = getTexts(child);
           if (ps.length < 2) continue;
           if (ps.length === 1 && HEADINGS.includes(ps[0])) continue;
           if (ps.every(t => SKIP_TEXT.some(s => t.includes(s)))) continue;
@@ -357,28 +454,73 @@ const extractEducationFromDetailPage = async () => {
         const HEADINGS = ['Experience', 'Education', 'Skills', 'Languages'];
         const SKIP_TEXT = ['Private to you', 'Visit our', 'Go to your', 'Recommendation transparency'];
 
-        const contentSection = document.querySelector('main > div > div > div:first-child');
+        const norm = (s) => s.replace(/\\s+/g, ' ').trim();
+        const getTexts = (el) => {
+          const seen = new Set();
+          const texts = [];
+          const add = (raw) => {
+            const t = norm(raw);
+            if (!t || t.length < 1 || seen.has(t)) return;
+            seen.add(t);
+            texts.push(t);
+          };
+          el.querySelectorAll('p').forEach(p => add(p.textContent));
+          if (texts.length < 2) {
+            el.querySelectorAll('span').forEach(span => {
+              const raw = span.textContent.trim();
+              if (!raw || raw.length < 2) return;
+              if (span.children.length > 0) {
+                const childConcat = norm(Array.from(span.children).map(c => c.textContent).join(''));
+                if (childConcat === norm(raw)) return;
+              }
+              if (span.offsetHeight === 0 && span.offsetWidth === 0) return;
+              add(raw);
+            });
+          }
+          return texts;
+        };
+
+        const contentSection = document.querySelector('main > div > div > div:first-child')
+          || document.querySelector('main section')
+          || document.querySelector('main');
         if (!contentSection) return education;
+
+        const hasEnoughText = (el) => {
+          if (el.querySelectorAll('p').length >= 1) return true;
+          let count = 0;
+          const seen = new Set();
+          el.querySelectorAll('span').forEach(s => {
+            const t = s.textContent.trim();
+            if (t.length < 3 || seen.has(t)) return;
+            if (s.children.length > 0) {
+              const cc = norm(Array.from(s.children).map(c => c.textContent).join(''));
+              if (cc === norm(t)) return;
+            }
+            seen.add(t);
+            count++;
+          });
+          return count >= 1;
+        };
+
         let container = null;
         let bestScore = 0;
         const walk = (el, depth) => {
           if (depth > 15) return;
           let score = 0;
           for (const c of el.children) {
-            if (c.tagName === 'DIV' && c.querySelectorAll('p').length >= 1) score++;
+            if ((c.tagName === 'DIV' || c.tagName === 'LI') && hasEnoughText(c)) score++;
           }
           if (score > bestScore) { bestScore = score; container = el; }
           for (const c of el.children) {
-            if (c.tagName === 'DIV' || c.tagName === 'SECTION') walk(c, depth + 1);
+            if (['DIV', 'SECTION', 'UL', 'LI'].includes(c.tagName)) walk(c, depth + 1);
           }
         };
         walk(contentSection, 0);
         if (!container) return education;
 
         for (const child of container.children) {
-          if (child.tagName !== 'DIV') continue;
-          const ps = Array.from(child.querySelectorAll('p'))
-            .map(p => p.textContent.trim()).filter(t => t.length > 0);
+          if (child.tagName !== 'DIV' && child.tagName !== 'LI') continue;
+          const ps = getTexts(child);
           if (ps.length === 0) continue;
           if (ps.length === 1 && (HEADINGS.includes(ps[0]) || ps[0].length < 20)) continue;
           if (ps.every(t => SKIP_TEXT.some(s => t.includes(s)))) continue;
@@ -419,28 +561,73 @@ const extractSkillsFromDetailPage = async () => {
         const HEADINGS = ['Experience', 'Education', 'Skills', 'Languages'];
         const SKIP_TEXT = ['Private to you', 'Visit our', 'Go to your', 'Recommendation transparency'];
 
-        const contentSection = document.querySelector('main > div > div > div:first-child');
+        const norm = (s) => s.replace(/\\s+/g, ' ').trim();
+        const getTexts = (el) => {
+          const seen = new Set();
+          const texts = [];
+          const add = (raw) => {
+            const t = norm(raw);
+            if (!t || t.length < 1 || seen.has(t)) return;
+            seen.add(t);
+            texts.push(t);
+          };
+          el.querySelectorAll('p').forEach(p => add(p.textContent));
+          if (texts.length < 2) {
+            el.querySelectorAll('span').forEach(span => {
+              const raw = span.textContent.trim();
+              if (!raw || raw.length < 2) return;
+              if (span.children.length > 0) {
+                const childConcat = norm(Array.from(span.children).map(c => c.textContent).join(''));
+                if (childConcat === norm(raw)) return;
+              }
+              if (span.offsetHeight === 0 && span.offsetWidth === 0) return;
+              add(raw);
+            });
+          }
+          return texts;
+        };
+
+        const contentSection = document.querySelector('main > div > div > div:first-child')
+          || document.querySelector('main section')
+          || document.querySelector('main');
         if (!contentSection) return skills;
+
+        const hasEnoughText = (el) => {
+          if (el.querySelectorAll('p').length >= 1) return true;
+          let count = 0;
+          const seen = new Set();
+          el.querySelectorAll('span').forEach(s => {
+            const t = s.textContent.trim();
+            if (t.length < 3 || seen.has(t)) return;
+            if (s.children.length > 0) {
+              const cc = norm(Array.from(s.children).map(c => c.textContent).join(''));
+              if (cc === norm(t)) return;
+            }
+            seen.add(t);
+            count++;
+          });
+          return count >= 1;
+        };
+
         let container = null;
         let bestScore = 0;
         const walk = (el, depth) => {
           if (depth > 15) return;
           let score = 0;
           for (const c of el.children) {
-            if (c.tagName === 'DIV' && c.querySelectorAll('p').length >= 1) score++;
+            if ((c.tagName === 'DIV' || c.tagName === 'LI') && hasEnoughText(c)) score++;
           }
           if (score > bestScore) { bestScore = score; container = el; }
           for (const c of el.children) {
-            if (c.tagName === 'DIV' || c.tagName === 'SECTION') walk(c, depth + 1);
+            if (['DIV', 'SECTION', 'UL', 'LI'].includes(c.tagName)) walk(c, depth + 1);
           }
         };
         walk(contentSection, 0);
         if (!container) return skills;
 
         for (const child of container.children) {
-          if (child.tagName !== 'DIV') continue;
-          const ps = Array.from(child.querySelectorAll('p'))
-            .map(p => p.textContent.trim()).filter(t => t.length > 0);
+          if (child.tagName !== 'DIV' && child.tagName !== 'LI') continue;
+          const ps = getTexts(child);
           if (ps.length === 0) continue;
           if (ps.length === 1 && (HEADINGS.includes(ps[0]) || ps[0].length < 3)) continue;
           if (ps.every(t => SKIP_TEXT.some(s => t.includes(s)))) continue;
@@ -468,28 +655,73 @@ const extractLanguagesFromDetailPage = async () => {
         const HEADINGS = ['Experience', 'Education', 'Skills', 'Languages'];
         const SKIP_TEXT = ['Private to you', 'Visit our', 'Go to your', 'Recommendation transparency'];
 
-        const contentSection = document.querySelector('main > div > div > div:first-child');
+        const norm = (s) => s.replace(/\\s+/g, ' ').trim();
+        const getTexts = (el) => {
+          const seen = new Set();
+          const texts = [];
+          const add = (raw) => {
+            const t = norm(raw);
+            if (!t || t.length < 1 || seen.has(t)) return;
+            seen.add(t);
+            texts.push(t);
+          };
+          el.querySelectorAll('p').forEach(p => add(p.textContent));
+          if (texts.length < 2) {
+            el.querySelectorAll('span').forEach(span => {
+              const raw = span.textContent.trim();
+              if (!raw || raw.length < 2) return;
+              if (span.children.length > 0) {
+                const childConcat = norm(Array.from(span.children).map(c => c.textContent).join(''));
+                if (childConcat === norm(raw)) return;
+              }
+              if (span.offsetHeight === 0 && span.offsetWidth === 0) return;
+              add(raw);
+            });
+          }
+          return texts;
+        };
+
+        const contentSection = document.querySelector('main > div > div > div:first-child')
+          || document.querySelector('main section')
+          || document.querySelector('main');
         if (!contentSection) return languages;
+
+        const hasEnoughText = (el) => {
+          if (el.querySelectorAll('p').length >= 1) return true;
+          let count = 0;
+          const seen = new Set();
+          el.querySelectorAll('span').forEach(s => {
+            const t = s.textContent.trim();
+            if (t.length < 3 || seen.has(t)) return;
+            if (s.children.length > 0) {
+              const cc = norm(Array.from(s.children).map(c => c.textContent).join(''));
+              if (cc === norm(t)) return;
+            }
+            seen.add(t);
+            count++;
+          });
+          return count >= 1;
+        };
+
         let container = null;
         let bestScore = 0;
         const walk = (el, depth) => {
           if (depth > 15) return;
           let score = 0;
           for (const c of el.children) {
-            if (c.tagName === 'DIV' && c.querySelectorAll('p').length >= 1) score++;
+            if ((c.tagName === 'DIV' || c.tagName === 'LI') && hasEnoughText(c)) score++;
           }
           if (score > bestScore) { bestScore = score; container = el; }
           for (const c of el.children) {
-            if (c.tagName === 'DIV' || c.tagName === 'SECTION') walk(c, depth + 1);
+            if (['DIV', 'SECTION', 'UL', 'LI'].includes(c.tagName)) walk(c, depth + 1);
           }
         };
         walk(contentSection, 0);
         if (!container) return languages;
 
         for (const child of container.children) {
-          if (child.tagName !== 'DIV') continue;
-          const ps = Array.from(child.querySelectorAll('p'))
-            .map(p => p.textContent.trim()).filter(t => t.length > 0);
+          if (child.tagName !== 'DIV' && child.tagName !== 'LI') continue;
+          const ps = getTexts(child);
           if (ps.length === 0) continue;
           if (ps.length === 1 && (HEADINGS.includes(ps[0]) || ps[0].length < 3)) continue;
           if (ps.every(t => SKIP_TEXT.some(s => t.includes(s)))) continue;
@@ -567,18 +799,18 @@ const scrollToLoadContent = async () => {
 
   // ═══ Find profile URL ═══
   await page.setData('status', 'Finding your profile...');
-  await page.goto('https://www.linkedin.com/feed/');
+  await page.goto('https://www.linkedin.com/feed/', { timeout: 60000 });
   await page.sleep(3000);
 
   const profileUrl = await getProfileUrl();
 
   if (!profileUrl) {
     await page.setData('status', 'Navigating to your profile...');
-    await page.goto('https://www.linkedin.com/in/me/');
+    await page.goto('https://www.linkedin.com/in/me/', { timeout: 60000 });
     await page.sleep(3000);
   } else {
     await page.setData('status', 'Navigating to your profile...');
-    await page.goto(profileUrl);
+    await page.goto(profileUrl, { timeout: 60000 });
     await page.sleep(3000);
   }
 


### PR DESCRIPTION
## Summary

- **Hero extractor**: LinkedIn moved profile name from `<h2>` to `<h1>`, and headline/location/connections from `<p>` to `<span>`/`<div>`. Rewrote hero extraction to handle both, with whitespace normalization and wrapper element detection.
- **Detail page extractors** (experience, education, skills, languages): LinkedIn uses `<span>` instead of `<p>` for entry text, plus a dual-text pattern (visible + accessible spans side by side causing duplication like "RTCKRTCK"). Added `getTexts()` helper that prefers `<p>`, falls back to leaf `<span>`, normalizes whitespace, and skips invisible screen-reader spans.
- **Container finding**: Falls back from `main > div > div > div:first-child` to `main section` to `main` for resilience against further DOM changes. Also walks `<ul>`/`<li>` elements.

## Test plan

- [ ] Run LinkedIn connector and verify profile name, headline, location, connections are extracted correctly
- [ ] Verify experience entries don't have doubled text (e.g. "RTCKRTCK" or "2008 - 20132008 - 2013")
- [ ] Verify education, skills, and languages are populated
- [ ] Verify data shows up in personal server after export

🤖 Generated with [Claude Code](https://claude.com/claude-code)