### PR TITLE
fix(linkedin): add multi-method fallback for detail page extraction

### DIFF
--- a/linkedin/linkedin-playwright.json
+++ b/linkedin/linkedin-playwright.json
@@ -1,6 +1,6 @@
 {
   "id": "linkedin-playwright",
-  "version": "1.0.0",
+  "version": "3.0.0",
   "name": "LinkedIn",
   "company": "LinkedIn",
   "description": "Exports your LinkedIn profile including experience, education, and skills using Playwright browser automation.",


### PR DESCRIPTION
## Summary

The v3 API-based LinkedIn connector (`extractDetailPageEntities`) only checked `<code id="bpr-guid-XXX">` elements for API data, which are absent in headless Chrome. Network captures were registered before page navigation but never read by the extractor, and were cleared prematurely in the Load More loop.

**Result**: Profile header worked (via miniProfile fallback) but all detail pages (experience, education, skills, languages) returned 0 items.

### Changes
- `extractDetailPageEntities` now tries 3 methods in order: `<code>` elements → captured network responses → in-browser Voyager API fetch (`/profileView`)
- `navigateToDetailPage` no longer clears captures in the Load More loop (preserves initial capture)
- Added DOM scraping fallback (`span[aria-hidden="true"]`) to all 4 detail page extractors as absolute last resort
- Improved `getProfileUrl` with DOM link extraction fallback from the feed page
- Added vanity URL resolution via `<link rel="canonical">` and client-side redirect detection
- New helpers: `fetchVoyagerApi` (in-browser fetch with CSRF token), `getVanityName`

## Test plan
- [x] Tested in headless mode: **12 experiences, 7 education, 41 skills, 6 languages** extracted successfully
- [x] Verify data quality (field values, no duplicates, no garbage text)
- [ ] Test with headed mode login flow
- [ ] Test on a profile with no experience/education sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)