### PR TITLE
Feedback: tighten vana-connect contributor workflow and docs

### DIFF
--- a/.claude/skills/skill-to-evals/PROJECT_NOTES.md
+++ b/.claude/skills/skill-to-evals/PROJECT_NOTES.md
@@ -1,0 +1,302 @@
+# Skill To Evals Project Notes
+
+## Purpose
+
+This document records how the `skill-to-evals` work evolved, which inputs shaped it, and what we learned from building `v1` and `v2`.
+
+## Sources
+
+### Repos and local references
+
+- `data-connect`
+  - `.agents/skills/skill-to-evals/SKILL.md`
+  - `.agents/skills/skill-to-evals-v2/SKILL.md`
+  - `.agents/skills/skill-creator-anthropic/SKILL.md`
+  - `.agents/skills/skill-creator-anthropic/references/schemas.md`
+  - `.agents/skills/skill-creator-anthropic/agents/grader.md`
+  - `.agents/skills/skill-creator-anthropic/eval-viewer/generate_review.py`
+- system skill creator
+  - `/Users/cflack/.codex/skills/.system/skill-creator/SKILL.md`
+  - `/Users/cflack/.codex/skills/.system/skill-creator/scripts/quick_validate.py`
+- external repo
+  - `https://github.com/ehmo/platform-design-skills`
+  - especially `skills/web/SKILL.md`, `skills/web/AGENTS.md`, and `skills/web/rules/_sections.md`
+
+### Notes and links provided in conversation
+
+- the eval-first notes starting from:
+  - `Started: plan -> implement -> review -> fix`
+  - `Now: evals -> prod spec -> ...`
+- the follow-up notes about:
+  - letting models draft the eval outline
+  - turning evals into hooks when possible
+  - collecting guides and papers, then converting them into skills and evals
+  - using autoresearch when a predictable outcome exists
+  - revisiting older projects after improving evals
+- the example references to Russ Cox:
+  - `https://swtch.com/~rsc/worknotes/`
+  - `https://research.swtch.com/names`
+- the Notion page:
+  - `https://www.notion.so/callum/I-now-essentially-spend-90-of-time-working-on-evals-32dc1b8a6eed8024b714fc7649db6a19?source=copy_link`
+
+## How We Approached It
+
+### 1. Initial framing
+
+The starting task was to create a skill that takes an existing skill document and compiles it into executable evals.
+
+The first useful framing choice was:
+
+- treat the output as eval artifacts, not as a rewritten skill
+- convert each rule into a testable check
+- split hard constraints from soft quality signals
+- include hook-style enforcement ideas for hard constraints
+- require at least one concrete failing example for each strong emitted eval
+
+This produced the first draft of `skill-to-evals`.
+
+### 2. Correction on source of truth
+
+An important course correction happened early:
+
+- use the system `skill-creator` as the main authoring skill
+- do not treat the repo-local `skill-creator` as the canonical creation workflow for this task
+
+That tightened the skill structure and reduced accidental drift.
+
+### 3. Learning from the Anthropic skill-creator
+
+The repo-local Anthropic variant added an important idea:
+
+- evals are part of a system, not just a list
+
+The key pieces were:
+
+- `evals/evals.json`
+- explicit expectations/assertions
+- grader evidence
+- benchmark aggregation
+- viewer-based review
+
+That changed the project in a meaningful way. The skill needed to produce checks that a grader could actually verify with evidence, not just checks that looked neat in YAML.
+
+This pushed `v1` toward:
+
+- binary checks
+- evidence-friendly `pass_if` and `fail_if`
+- omission of untestable guidance
+- stronger rejection of shallow compliance
+
+### 4. Learning from the eval-first notes
+
+The conversation notes shifted the mental model again.
+
+The strongest ideas were:
+
+- evals come before product specs
+- stronger guardrails produce clearer specs and better outputs
+- good evals often become hooks
+- evals should be revised continuously and backtested on old projects
+
+This implied that `skill-to-evals` should not merely emit checks. It should compile guidance into something closer to a guardrail layer.
+
+### 5. Learning from `platform-design-skills`
+
+The `ehmo/platform-design-skills` repo showed a useful structure for that compiler model:
+
+- long-form guidance exists, but the important unit is the atomic rule
+- sectioning matters
+- priority labels matter
+- "never do" rules are naturally hook-ready
+- a flat list loses too much information
+
+The most useful file for this was `skills/web/rules/_sections.md`, because it looks more like compilation-ready source material than like prose.
+
+That led to `skill-to-evals-v2`.
+
+## What Changed Between V1 and V2
+
+### V1
+
+`v1` focuses on converting rules into concise machine-checkable evals.
+
+Core ideas:
+
+- hard vs soft classification
+- explicit `pass_if` / `fail_if`
+- hook suggestion for hard constraints
+- omit non-testable source material
+- prefer discriminating checks over shallow ones
+
+This is a good rule-to-check compiler.
+
+### V2
+
+`v2` treats the task more like guardrail compilation.
+
+New ideas added in `v2`:
+
+- stable IDs instead of simple sequence numbers
+- preserved `section`
+- preserved `priority`
+- preserved `source_order`
+- explicit `source_ref`
+- explicit `evidence_target`
+- stronger emphasis on repo-hook and harness-gate compatibility
+- explicit source spans when available
+- concrete counterexamples
+- first-class hookability
+
+This is closer to a practical eval system compiler.
+
+## Main Learnings So Far
+
+### 1. A skill is not automatically an eval source
+
+A large `SKILL.md` is usually too mixed:
+
+- explanation
+- examples
+- rationale
+- norms
+- actual rules
+
+The first job is normalization, not direct conversion.
+
+### 2. Atomic rules are the real input
+
+The best source material for eval generation looks like:
+
+- sectioned
+- prioritized
+- imperative
+- independently testable
+
+This is why the `platform-design-skills` rule files were so informative.
+
+The next improvement on top of this is to make the normalized rule IR explicit:
+
+- source guidance is not the same thing as a compiled rule
+- evals should be emitted from normalized rules, not directly from prose
+- that IR is the stable layer for regeneration, auditing, and diffing
+
+### 3. Hard constraints should be hook-first
+
+If a hard rule cannot plausibly become:
+
+- a repo hook
+- a harness gate
+- a lint-style rejection
+- a deterministic test gate
+
+then it is probably too weak, too vague, or misclassified.
+
+The important refinement is to separate:
+
+- hookability: can this realistically be enforced, and where
+- hook suggestion: what is the narrowest concrete mechanism
+
+### 4. Good evals are discriminating
+
+A weak check passes when the output is superficially compliant.
+
+A useful check fails:
+
+- wrong structure
+- wrong behavior
+- wrong content
+- coincidental matches
+
+This came directly from the Anthropic grader model and from the eval-first notes.
+
+A simple way to raise the discrimination bar is to require one explicit counterexample for each emitted eval.
+
+### 5. Evidence matters as much as the rule
+
+An eval without a clear evidence target is hard to grade and hard to trust.
+
+Useful evidence targets include:
+
+- output
+- diff
+- transcript
+- AST
+- DOM
+- deterministic tests
+
+This is why `v2` carries `evidence_target` explicitly.
+
+The same logic applies to provenance:
+
+- exact source spans are better than vague section references
+- exact spans make regeneration and source-diff review much easier
+
+### 6. Flattening loses too much information
+
+A flat list of anonymous checks throws away:
+
+- where the rule came from
+- how important it is
+- what section it belongs to
+- whether it should block or merely score
+
+That makes regeneration, auditing, and backtesting harder.
+
+### 7. The destination is a guardrail system, not a YAML file
+
+The most important lesson from the notes is that the output artifact matters less than the enforcement model.
+
+The path is:
+
+- collect rules
+- normalize them
+- compile them into evals
+- turn the strong ones into hooks
+- benchmark and review the rest
+- revise and backtest
+
+Backtesting should be treated as a first-class system component, not a later nice-to-have:
+
+- each eval compiler should have a small pass/fail corpus
+- strong hard constraints should be checked against old examples
+- regressions in the compiler are easier to spot when the corpus is stable
+
+## Working Model Emerging From This Project
+
+The emerging compiler pipeline is:
+
+1. ingest source guidance
+2. normalize into atomic rules
+3. preserve section, priority, provenance, and exact source spans
+4. classify each rule as hard or soft
+5. choose the strongest observable evidence target
+6. attach a concrete counterexample
+7. record hookability and then attach the narrowest viable hook suggestion
+8. emit guardrail-ready evals
+9. promote strong hard constraints into hooks where possible
+10. backtest and benchmark the remainder over time
+
+## Current Open Questions
+
+- Should the next version emit both guardrails and benchmark assertions as separate outputs?
+- Should the normalized-rule IR be optionally emitted for auditability, or remain internal by default?
+- Should backtest corpus management live beside the skill, or in a separate eval package?
+
+## Current Artifacts
+
+- v1: `.agents/skills/skill-to-evals/SKILL.md`
+- v2: `.agents/skills/skill-to-evals-v2/SKILL.md`
+
+## Summary
+
+The project started as "convert rules into checks."
+
+It has moved toward:
+
+- compile rule systems, not prose
+- preserve structure and provenance
+- make normalized rules the true compiler input
+- optimize for enforcement, evidence, and backtesting
+- treat hooks as the strongest form of eval when possible
+
+That shift is the main thing learned so far.

--- a/.claude/skills/skill-to-evals/SKILL.md
+++ b/.claude/skills/skill-to-evals/SKILL.md
@@ -1,0 +1,273 @@
+---
+name: skill-to-evals-v2
+description: Convert a skill document, guide, paper summary, or rule set into guardrail-ready evals with stable IDs, section and priority preservation, explicit provenance, counterexamples, evidence targets, and hookability. Use when the user wants to turn rules into enforceable checks, repo hooks, harness gates, or benchmark assertions rather than prose guidance.
+---
+
+# Skill To Evals V2
+
+## Goal
+
+Compile source guidance into eval artifacts that can drive:
+
+- repo hooks
+- harness gates
+- benchmark assertions
+- review checklists
+
+Output evals only.
+
+- Do not restate or summarize the source.
+- Do not give advice or remediation.
+- Do not emit explanatory prose outside the output block.
+- Omit source content that cannot become a discriminating check.
+
+## Compilation model
+
+Treat the source as raw material for a guardrail system, not as prose to paraphrase.
+
+Compile in this order:
+
+1. normalize the source into atomic rules internally
+2. preserve source section, priority, and exact span when available
+3. split mixed rules into independently testable units
+4. classify each unit as hard or soft
+5. choose the strongest observable evidence target
+6. record one concrete counterexample for each emitted eval
+7. attach hookability and the narrowest viable hook strategy
+
+## What to extract
+
+Convert only normative content:
+
+- required actions
+- forbidden actions
+- exact output contracts
+- ordering constraints
+- scope boundaries
+- safety boundaries
+- tool or file restrictions
+- measurable thresholds stated by the source
+
+Do not convert:
+
+- introductions
+- motivation
+- background explanation
+- duplicated guidance
+- aspirational statements with no observable signal
+- requirements that depend on hidden intent
+- requirements that cannot be verified from output, diff, transcript, DOM, AST, or deterministic tests
+
+## Rule normalization
+
+Before emitting evals, construct an internal normalized-rule IR.
+
+The IR is not part of the final output unless the user explicitly asks for it.
+
+Each normalized rule should capture:
+
+- atomic rule text
+- section
+- priority
+- source order
+- source reference
+- exact source span when available
+- whether the rule is normative enough to emit
+
+Before emitting evals from that IR:
+
+- keep each rule atomic
+- preserve section names
+- preserve explicit priority labels such as `CRITICAL`, `HIGH`, `MEDIUM`, `LOW`
+- preserve explicit source ordering within each section
+- carry enough provenance to regenerate the eval from updated source material
+- preserve exact heading and line or span references when available
+
+If the source mixes a hard prohibition with softer advice, split them into separate evals.
+
+## Eval quality bar
+
+Every eval must be:
+
+- atomic
+- binary
+- observable
+- evidence-friendly
+- discriminating
+- backed by at least one concrete failing counterexample
+
+Reject weak conversions such as:
+
+- filename-only checks when file content matters
+- presence-only checks when correctness matters
+- text-match checks when structure or behavior matters
+- process checks unless the source explicitly requires the process itself
+
+If a shallow or coincidental success would pass the check, tighten it or omit it.
+
+## Classification
+
+Use exactly one classification per eval:
+
+- `hard_constraint`: violation should reject the run
+- `soft_score`: violation is a quality signal only
+
+Default `hard_constraint` for:
+
+- `must`, `must not`, `never`, `always`, `only`, `exactly`
+- explicit bans
+- safety and policy boundaries
+- strict formatting or structural contracts
+- explicit thresholds
+- "never do" style rules
+
+Default `soft_score` for:
+
+- `prefer`, `avoid`, `keep`, `try`, `usually`
+- style and quality heuristics
+- guidance where multiple outputs could still be acceptable
+
+If ambiguous, use `soft_score`.
+
+## Evidence target
+
+Each eval must declare the strongest primary evidence target:
+
+- `output`
+- `diff`
+- `transcript`
+- `ast`
+- `dom`
+- `test`
+- `manual`
+
+Choose the strongest target that can actually verify the rule.
+
+- Prefer `ast` or `dom` over plain text when structure matters.
+- Prefer `test` when runtime behavior is the real requirement.
+- Prefer `output` over `transcript` unless the rule is explicitly about process.
+- Use `manual` only when no reliable automated target exists.
+
+## Hook strategy
+
+Every eval must include `hookability`.
+
+Every `hard_constraint` must also include a hook suggestion.
+
+Allowed hookability values:
+
+- `repo_hook`
+- `harness_gate`
+- `manual_only`
+
+Allowed hook kinds:
+
+- `regex`
+- `ast`
+- `dom_audit`
+- `diff_gate`
+- `output_gate`
+- `test_gate`
+- `manual_only`
+
+Choose the narrowest hook that could reject a violation with low ambiguity.
+
+## Output contract
+
+Return exactly one fenced `yaml` block and nothing else.
+
+Use this schema exactly:
+
+```yaml
+evals:
+  - id: HC-ACCESSIBILITY-001
+    section: Accessibility / WCAG
+    priority: CRITICAL
+    source_order: 1
+    source_ref: Accessibility / WCAG > Rule 1
+    source_span: lines 12-18
+    classification: hard_constraint
+    evidence_target: ast
+    hookability: repo_hook
+    check: Use semantic HTML instead of clickable non-semantic elements when a native control exists.
+    pass_if:
+      - Interactive controls are implemented with native semantic elements where applicable.
+    fail_if:
+      - A non-semantic element such as a clickable `div` is used where a native control would satisfy the same behavior.
+    counterexample:
+      - JSX uses a clickable `div` for button behavior without a valid semantic exception.
+    hook_suggestion:
+      kind: ast
+      reject_if:
+        - JSX or HTML contains click handlers on non-interactive elements for button-like behavior when no valid semantic exception is present.
+  - id: SS-TYPOGRAPHY-001
+    section: Typography
+    priority: HIGH
+    source_order: 3
+    source_ref: Typography > Rule 3
+    source_span: lines 41-45
+    classification: soft_score
+    evidence_target: output
+    hookability: manual_only
+    check: Keep body typography concise and readable.
+    pass_if:
+      - Body text style stays consistent and supports easy scanning.
+    fail_if:
+      - Body text style is inconsistent or clearly harms readability.
+    counterexample:
+      - Body text uses multiple inconsistent styles that make scanning noticeably harder.
+```
+
+## Formatting rules
+
+- Emit `hard_constraint` evals before `soft_score` evals.
+- Preserve source order within each classification.
+- IDs must be stable and derived from classification, section slug, and source order.
+- Use uppercase priority labels exactly as they appear in the source when present.
+- If the source has no explicit priority, omit `priority`.
+- If the source has no meaningful section, use `General`.
+- Include `source_span` when the source exposes exact headings, lines, or ranges.
+- Do not include fields outside the schema.
+- Do not include empty arrays or empty objects.
+
+## Conversion rules
+
+- Prefer outcome checks over process checks unless process compliance is itself the rule.
+- Prefer content correctness over surface presence.
+- Prefer structure and behavior over wording when those are the true requirement.
+- Encode explicit numeric thresholds exactly as stated by the source.
+- Do not invent thresholds, priorities, or policies not present or strongly implied in the source.
+- If multiple evidence targets are possible, choose the one most suitable for automated enforcement.
+- If the source contains a reusable hard prohibition, phrase it so it can become a repo or harness guardrail.
+- If the source contains high-level guidance that cannot support a hard gate, keep it as a soft score or omit it.
+- `counterexample` must describe a realistic failing case, not a paraphrase of `fail_if`.
+- `hookability` should capture whether the rule is realistically enforceable in a repo hook, a harness gate, or only manual review.
+- Prefer exact source spans over vague provenance when the source format allows it.
+
+## Omission rules
+
+Do not emit an eval when:
+
+- the rule is too vague to fail decisively
+- the rule cannot produce concrete evidence
+- the rule would reward shallow compliance
+- the rule duplicates a stronger emitted eval
+
+## Quality test
+
+A good result is:
+
+- compact
+- source-faithful
+- guardrail-ready
+- benchmark-ready
+- easy to grade with evidence
+- easy to backtest against known pass and fail examples
+
+A bad result is:
+
+- summary disguised as evals
+- flattened output that loses section or priority
+- checks that pass for coincidental compliance
+- hard constraints with no realistic enforcement path
+- evals with no concrete failing counterexample

--- a/VANA_CONNECTORS_SKILL_FEEDBACK.md
+++ b/VANA_CONNECTORS_SKILL_FEEDBACK.md
@@ -1,0 +1,178 @@
+# Vana Connect Skill Feedback
+
+This note captures what we learned while building the Claude connector in this repo. The goal is not to criticize the skill or docs in the abstract; it is to record where they helped, where they were confusing, and what would make the next connector build smoother for the team.
+
+## Context
+
+We built and validated a new Claude connector that:
+
+- exports full conversation threads
+- exports project list and project detail
+- runs through the `vana` CLI
+- validates against the connector schemas and real exported output
+
+This feedback comes from actually using the current skill/docs to get a real connector over the line.
+
+## What Worked Well
+
+- The overall connector model is good: research first, implement, validate, register.
+- The advice to inspect the live login surface instead of guessing was correct and important.
+- The page API reference was useful and mostly accurate for writing connector code.
+- The extraction patterns doc was directionally helpful once we had real platform evidence.
+- The repo’s validation step was valuable. It caught real issues and acted as a quality gate.
+
+## What Was Confusing Or Not Good Enough
+
+### 1. The docs describe more than one workflow as if they are all current
+
+In practice, we found multiple overlapping workflows:
+
+- `vana sources`
+- `vana connect`
+- `node run-connector.cjs ...`
+- `skills/vana-connect/scripts/run-connector.cjs ...`
+- references to `~/.dataconnect/...`
+
+That makes it hard to know which path is the real source of truth for someone working inside this repo today.
+
+### 2. Runtime/path documentation appears stale
+
+The skill and some docs still refer to:
+
+- `~/.dataconnect/`
+
+But on this machine, the live runtime state, logs, and results were under:
+
+- `~/.vana/`
+
+This is a high-friction mismatch because it affects setup, validation, log inspection, and debugging.
+
+### 3. Validator command naming is inconsistent
+
+We ran into multiple validator entrypoints:
+
+- `node scripts/validate-connector.cjs ...`
+- `node skills/vana-connect/scripts/validate.cjs ...`
+- references in docs to `node scripts/validate.cjs ...`
+
+This is confusing for a contributor because the command names are very similar but the repo organization suggests different intended entrypoints.
+
+### 4. Local repo discovery through `vana` is not explained clearly enough
+
+One of the most important practical discoveries was that `vana` can discover connectors from this repo when run from the repo root because it finds `registry.json`.
+
+That behavior mattered a lot, but it was not obvious from the docs. We had to verify it by inspecting behavior and runtime code.
+
+### 5. The standalone runner path was misleading for this repo workflow
+
+Some docs and README content still imply that the standalone runner is a normal local testing path.
+
+In our actual workflow, the reliable path was:
+
+- `vana connect claude --json --no-input`
+
+The older `run-connector` path was not the one that got us through the live connector iteration loop.
+
+### 6. README is behind reality
+
+The root README still reads like an older runner-centric architecture in places. That creates confusion because the skill pushes the CLI-first flow while the README still teaches another mental model.
+
+### 7. Schema validation has at least one surprising behavior that is not documented
+
+We hit a validator gotcha where nullable fields listed as `required` were effectively treated as missing in output validation.
+
+That is important enough to document because it creates avoidable confusion while enriching schemas.
+
+### 8. It is not explicit enough when manual-login-first is acceptable
+
+The docs talk about automated credential flows, env vars, and requestInput patterns, but they do not say strongly enough that:
+
+- manual login is acceptable
+- manual login is often the right tradeoff for brittle auth surfaces
+- a connector can still be mergeable and useful even without automated login
+
+That would have reduced uncertainty during the Claude build.
+
+## What We Had To Learn Ourselves
+
+- The live Claude app used authenticated APIs that were not discoverable from the skill alone.
+- The correct local execution path was the `vana` CLI, not the older standalone runner guidance.
+- The runtime state was under `~/.vana`, not `~/.dataconnect`.
+- The local repo could act as a source registry for `vana` when run from this checkout.
+- The validator had behavior that was stricter or stranger than the docs implied.
+
+These are exactly the kinds of things the skill/docs should surface earlier.
+
+## Improvements I Would Suggest
+
+### 1. Make one workflow canonical
+
+For contributors working in this repo, the docs should state a single primary path such as:
+
+- use `vana sources --json`
+- use `vana connect <platform> --json --no-input`
+- use `node scripts/validate-connector.cjs ...`
+- use `node skills/vana-connect/scripts/register.cjs ...`
+
+Everything else should be described as secondary, legacy, or debugging-only if that is the case.
+
+### 2. Add a short "current architecture" section
+
+This should explain:
+
+- what the current CLI is
+- how local repo discovery works
+- where runtime state and logs live
+- how results are stored
+- when the connector is being pulled from the repo versus a cached location
+
+### 3. Unify validator guidance
+
+Pick one validator command to recommend in the main workflow and explain when the others are relevant.
+
+### 4. Document common gotchas
+
+A short "known friction points" section would help a lot:
+
+- nullable + required schema behavior
+- need to re-register after connector edits
+- browser session reuse can hide auth problems
+- manual login is often acceptable
+- real-platform inspection beats remembered product knowledge
+
+### 5. Update the README to match the actual contributor path
+
+The README should align with the CLI-first reality if that is now the intended workflow.
+
+### 6. Add a "what good looks like" checklist for connector PRs
+
+For example:
+
+- connector works against a real account
+- structure validation passes
+- output validation passes
+- scopes are meaningful
+- PR explains tradeoffs and known follow-ups
+- unrelated repo/tooling churn is avoided unless necessary
+
+### 7. Be more explicit about acceptable auth tradeoffs
+
+The docs should say plainly that a connector can still be valid and mergeable if:
+
+- it is manual-login-first
+- auth automation is deferred to a follow-up
+- the data extraction itself is strong and validated
+
+That would help contributors avoid over-engineering before first review.
+
+## Suggested Next Step For The Team
+
+Discuss whether the current docs should be tightened around a single contributor workflow before adding more connectors.
+
+The biggest opportunity is not adding more reference content. It is reducing ambiguity:
+
+- one canonical way to run
+- one canonical way to validate
+- one canonical explanation of runtime state and local discovery
+
+That would make the skill feel much more trustworthy in practice.


### PR DESCRIPTION
## Why I am opening this
This PR is a discussion vehicle, not a code/docs patch proposal. The branch only contains an empty commit so the feedback can live in the PR description rather than in the repo.

While building and validating the Claude connector, I found the overall connector model strong, but I also hit enough ambiguity in the skill/docs/runtime story that I think it is worth aligning as a team before we add more connectors.

## What worked well
- the overall connector shape is good: research, implement, validate, register
- the guidance to inspect the live product instead of guessing was correct and important
- the page API reference was useful in practice
- the validator did real work as a quality gate

## What was confusing or not good enough
### 1. Too many overlapping workflows
In practice I found multiple paths described as if they were all current:
- `vana sources`
- `vana connect`
- `node run-connector.cjs ...`
- `skills/vana-connect/scripts/run-connector.cjs ...`
- references to `~/.dataconnect/...`

That makes it hard to know which workflow is actually canonical for contributors working inside this repo today.

### 2. Runtime/path drift
Some docs still refer to `~/.dataconnect`, but on my machine the live runtime state, logs, and results were under `~/.vana`. That mismatch affects setup, validation, and debugging.

### 3. Validator command drift
I ran into multiple validator entrypoints:
- `node scripts/validate-connector.cjs ...`
- `node skills/vana-connect/scripts/validate.cjs ...`
- docs that still mention `node scripts/validate.cjs ...`

This is unnecessarily confusing.

### 4. Local repo discovery through `vana` is under-documented
One of the most important practical discoveries was that `vana` can discover connectors from this repo when run from the repo root because it finds `registry.json`. That behavior mattered a lot and should be stated more clearly.

### 5. Standalone runner guidance felt stale for the actual repo workflow
In the real Claude build loop, the reliable path was the CLI:
- `vana connect claude --json --no-input`

The older runner-centric guidance was not the path that got the connector over the line.

### 6. README feels behind reality
The root README still reads like an older runner-centric architecture in places, while the skill points toward a CLI-first flow.

### 7. Validator gotchas are not documented clearly enough
I hit a validator behavior where nullable fields listed as `required` were effectively treated as missing in output validation. That is the kind of thing contributors should not have to discover the hard way.

### 8. Manual-login-first should be described more explicitly as acceptable
The docs talk a lot about credential flows, but they do not say strongly enough that a connector can still be valid and mergeable if it is manual-login-first because auth is brittle, CAPTCHA-heavy, or tied to third-party providers.

## What I had to learn by doing
- the live Claude app used authenticated APIs that were not discoverable from the skill alone
- the correct local execution path was the `vana` CLI, not the older standalone runner guidance
- the runtime state was under `~/.vana`, not `~/.dataconnect`
- the local repo could act as a source registry for `vana` when run from this checkout
- the validator had stricter/stranger behavior than the docs implied

## What I would improve
### 1. Make one workflow canonical
For contributors working in this repo, the docs should state a single primary path such as:
- use `vana sources --json`
- use `vana connect <platform> --json --no-input`
- use `node scripts/validate-connector.cjs ...`
- use `node skills/vana-connect/scripts/register.cjs ...`

Everything else should be described as secondary, legacy, or debugging-only if that is the case.

### 2. Add a short current-architecture section
This should explain:
- what the current CLI is
- how local repo discovery works
- where runtime state and logs live
- how results are stored
- when the connector is being pulled from the repo versus a cached location

### 3. Unify validator guidance
Pick one validator command to recommend in the main workflow and explain when the others are relevant.

### 4. Add a short known-gotchas section
For example:
- nullable + required schema behavior
- need to re-register after connector edits
- browser session reuse can hide auth problems
- manual login is often acceptable
- real platform inspection beats remembered product knowledge

### 5. Update the README to match the actual contributor path
If the intended flow is now CLI-first, the README should reflect that more directly.

### 6. Add a what-good-looks-like checklist for connector PRs
For example:
- connector works against a real account
- structure validation passes
- output validation passes
- scopes are meaningful
- PR explains tradeoffs and follow-ups
- unrelated repo/tooling churn is avoided unless necessary

### 7. Be more explicit about acceptable auth tradeoffs
The docs should say plainly that a connector can still be valid and mergeable if:
- it is manual-login-first
- auth automation is deferred to a follow-up
- the data extraction itself is strong and validated

## Question for the team
Would it make sense to tighten the skill/docs around a single contributor workflow now, before adding many more connectors, so contributors spend less time reconciling multiple mental models?