### PR TITLE
feat: migrate connectors to requestData and requestManualAction APIs

### DIFF
--- a/github/github-playwright.js
+++ b/github/github-playwright.js
@@ -426,11 +426,15 @@ const extractStarred = async (username) => {
     // If programmatic login failed or form wasn't found, fall back to headed
     if (!loggedIn) {
       await page.setData("status", "Please complete login in the browser...");
-      await page.requestManualAction(
+      const manualResult = await page.requestManualAction(
         "Complete any remaining verification, then click 'Done'.",
         async () => await isLoggedIn(),
         { url: "https://github.com/login", interval: 2000 },
       );
+      if (manualResult.status === 'skipped') {
+        await page.setData('error', 'Login required but not available in automated mode.');
+        return;
+      }
     }
 
     loggedIn = await isLoggedIn();

--- a/github/github-playwright.js
+++ b/github/github-playwright.js
@@ -367,7 +367,7 @@ const extractStarred = async (username) => {
     `);
 
     if (hasLoginForm) {
-      const { username: loginUser, password } = await page.requestInput({
+      const credResult = await page.requestData({
         message: "Log in to GitHub",
         schema: {
           type: "object",
@@ -378,6 +378,11 @@ const extractStarred = async (username) => {
           required: ["username", "password"],
         },
       });
+      if (credResult.status === 'skipped') {
+        await page.setData('error', 'Login credentials required but not available in automated mode.');
+        return;
+      }
+      const { username: loginUser, password } = credResult.data;
 
       await page.evaluate(`document.querySelector('#login_field').value = ${JSON.stringify(loginUser)}`);
       await page.evaluate(`document.querySelector('#login_field').dispatchEvent(new Event('input', {bubbles:true}))`);
@@ -389,7 +394,7 @@ const extractStarred = async (username) => {
       // Handle 2FA if present
       const needs2fa = await page.evaluate(`!!document.querySelector('#app_totp, #sms_totp, [name="otp"]')`);
       if (needs2fa) {
-        const { code } = await page.requestInput({
+        const codeResult = await page.requestData({
           message: "Enter your GitHub 2FA code",
           schema: {
             type: "object",
@@ -397,6 +402,11 @@ const extractStarred = async (username) => {
             required: ["code"],
           },
         });
+        if (codeResult.status === 'skipped') {
+          await page.setData('error', '2FA code required but not available in automated mode.');
+          return;
+        }
+        const { code } = codeResult.data;
         await page.evaluate(`
           (() => {
             const input = document.querySelector('#app_totp, #sms_totp, [name="otp"]');
@@ -415,19 +425,12 @@ const extractStarred = async (username) => {
 
     // If programmatic login failed or form wasn't found, fall back to headed
     if (!loggedIn) {
-      const { headed } = await page.showBrowser("https://github.com/login");
-      if (headed) {
-        await page.setData("status", "Please complete login in the browser...");
-        await page.promptUser(
-          "Complete any remaining verification, then click 'Done'.",
-          async () => await isLoggedIn(),
-          2000,
-        );
-        await page.goHeadless();
-      } else {
-        await page.setData("error", "GitHub login failed. Login form not found or credentials incorrect.");
-        return;
-      }
+      await page.setData("status", "Please complete login in the browser...");
+      await page.requestManualAction(
+        "Complete any remaining verification, then click 'Done'.",
+        async () => await isLoggedIn(),
+        { url: "https://github.com/login", interval: 2000 },
+      );
     }
 
     loggedIn = await isLoggedIn();

--- a/google/youtube-playwright.js
+++ b/google/youtube-playwright.js
@@ -973,11 +973,15 @@ const scrapeHistory = async () => {
 
       // Fallback to headed browser if programmatic login failed
       if (!state.isLoggedIn) {
-        await page.requestManualAction(
+        const manualResult = await page.requestManualAction(
           'Complete any remaining verification, then click "Done".',
           async () => checkLoginStatus(),
           { url: 'https://www.youtube.com/', interval: 2000 }
         );
+        if (manualResult.status === 'skipped') {
+          await page.setData('error', 'Login required but not available in automated mode.');
+          return;
+        }
         state.isLoggedIn = await checkLoginStatus();
       }
 

--- a/google/youtube-playwright.js
+++ b/google/youtube-playwright.js
@@ -792,7 +792,7 @@ const scrapeHistory = async () => {
       `);
 
       if (hasEmailField) {
-        const { email } = await page.requestInput({
+        const emailResult = await page.requestData({
           message: "Log in to YouTube with your Google account — enter your email",
           schema: {
             type: "object",
@@ -802,6 +802,11 @@ const scrapeHistory = async () => {
             required: ["email"],
           },
         });
+        if (emailResult.status === 'skipped') {
+          await page.setData('error', 'Login credentials required but not available in automated mode.');
+          return;
+        }
+        const { email } = emailResult.data;
 
         await page.evaluate(`
           (() => {
@@ -833,7 +838,7 @@ const scrapeHistory = async () => {
         `);
 
         if (hasPasswordField) {
-          const { password } = await page.requestInput({
+          const passwordResult = await page.requestData({
             message: "Enter your Google account password",
             schema: {
               type: "object",
@@ -843,6 +848,11 @@ const scrapeHistory = async () => {
               required: ["password"],
             },
           });
+          if (passwordResult.status === 'skipped') {
+            await page.setData('error', 'Login credentials required but not available in automated mode.');
+            return;
+          }
+          const { password } = passwordResult.data;
 
           await page.evaluate(`
             (() => {
@@ -874,7 +884,7 @@ const scrapeHistory = async () => {
           window.location.href.includes('challenge')
         `);
         if (needs2fa) {
-          const { code } = await page.requestInput({
+          const codeResult = await page.requestData({
             message: "Enter your Google 2FA verification code",
             schema: {
               type: "object",
@@ -882,6 +892,11 @@ const scrapeHistory = async () => {
               required: ["code"],
             },
           });
+          if (codeResult.status === 'skipped') {
+            await page.setData('error', 'Login credentials required but not available in automated mode.');
+            return;
+          }
+          const { code } = codeResult.data;
           await page.evaluate(`
             (() => {
               const input = document.querySelector('input[name="totpPin"]') ||
@@ -958,16 +973,11 @@ const scrapeHistory = async () => {
 
       // Fallback to headed browser if programmatic login failed
       if (!state.isLoggedIn) {
-        const { headed } = await page.showBrowser('https://www.youtube.com/');
-        if (headed) {
-          await page.setData('status', 'Please complete login in the browser...');
-          await page.promptUser(
-            'Complete any remaining verification, then click "Done".',
-            async () => checkLoginStatus(),
-            2000
-          );
-          await page.goHeadless();
-        }
+        await page.requestManualAction(
+          'Complete any remaining verification, then click "Done".',
+          async () => checkLoginStatus(),
+          { url: 'https://www.youtube.com/', interval: 2000 }
+        );
         state.isLoggedIn = await checkLoginStatus();
       }
 

--- a/google/youtube-playwright.js
+++ b/google/youtube-playwright.js
@@ -973,6 +973,7 @@ const scrapeHistory = async () => {
 
       // Fallback to headed browser if programmatic login failed
       if (!state.isLoggedIn) {
+        await page.setData('status', 'Please complete login in the browser...');
         const manualResult = await page.requestManualAction(
           'Complete any remaining verification, then click "Done".',
           async () => checkLoginStatus(),

--- a/heb/heb-playwright.js
+++ b/heb/heb-playwright.js
@@ -628,14 +628,10 @@ const scrapeNutrition = async (productUrl, productId) => {
   let isLoggedIn = await checkLoginStatus();
 
   if (!isLoggedIn) {
-    await page.showBrowser('https://www.heb.com/my-account/your-orders');
-    await page.setData('status', 'Please sign in to your H-E-B account...');
-    await page.sleep(2000);
-
-    await page.promptUser(
+    await page.requestManualAction(
       'Sign in to your H-E-B account. Click "Done" when you see your order history.',
       async () => await checkLoginStatus(),
-      2000
+      { url: 'https://www.heb.com/my-account/your-orders', interval: 2000 }
     );
 
     await page.setData('status', 'Login confirmed');
@@ -754,17 +750,15 @@ const scrapeNutrition = async (productUrl, productId) => {
         await page.sleep(30000);
       }
 
-      await page.showBrowser(productUrl);
       await page.setData('status', 'Bot check detected — please complete the verification and click Done.');
-      await page.promptUser(
+      await page.requestManualAction(
         'H-E-B is showing a bot check. Complete the verification in the browser, then click "Done" to continue.',
         async () => {
           const check = await detectBlock();
           return !check.blocked;
         },
-        2000
+        { url: productUrl, interval: 2000 }
       );
-      await page.goHeadless();
       // Wait longer after solve to avoid immediate re-trigger
       await page.sleep(5000 + Math.floor(Math.random() * 3000));
       // Retry this product

--- a/heb/heb-playwright.js
+++ b/heb/heb-playwright.js
@@ -628,11 +628,15 @@ const scrapeNutrition = async (productUrl, productId) => {
   let isLoggedIn = await checkLoginStatus();
 
   if (!isLoggedIn) {
-    await page.requestManualAction(
+    const manualResult = await page.requestManualAction(
       'Sign in to your H-E-B account. Click "Done" when you see your order history.',
       async () => await checkLoginStatus(),
       { url: 'https://www.heb.com/my-account/your-orders', interval: 2000 }
     );
+    if (manualResult.status === 'skipped') {
+      await page.setData('error', 'Login required but not available in automated mode.');
+      return;
+    }
 
     await page.setData('status', 'Login confirmed');
     await page.sleep(1000);
@@ -751,7 +755,7 @@ const scrapeNutrition = async (productUrl, productId) => {
       }
 
       await page.setData('status', 'Bot check detected — please complete the verification and click Done.');
-      await page.requestManualAction(
+      const botCheckResult = await page.requestManualAction(
         'H-E-B is showing a bot check. Complete the verification in the browser, then click "Done" to continue.',
         async () => {
           const check = await detectBlock();
@@ -759,6 +763,10 @@ const scrapeNutrition = async (productUrl, productId) => {
         },
         { url: productUrl, interval: 2000 }
       );
+      if (botCheckResult.status === 'skipped') {
+        await page.setData('status', `Skipping product ${productId} — bot check not available in automated mode.`);
+        continue;
+      }
       // Wait longer after solve to avoid immediate re-trigger
       await page.sleep(5000 + Math.floor(Math.random() * 3000));
       // Retry this product

--- a/linkedin/linkedin-playwright.js
+++ b/linkedin/linkedin-playwright.js
@@ -262,7 +262,7 @@ const extractYears = (obj) => {
           },
         });
         if (tfaResult.status === 'skipped') {
-          await page.setData('error', 'Login credentials required but not available in automated mode.');
+          await page.setData('error', 'Verification code required but not available in automated mode.');
           return;
         }
         const { code } = tfaResult.data;
@@ -327,6 +327,7 @@ const extractYears = (obj) => {
 
     // Fallback to manual browser login if programmatic login failed
     if (!isAuthenticated) {
+      await page.setData('status', 'Please complete login in the browser...');
       const manualResult = await page.requestManualAction(
         'Complete any remaining verification, then click "Done".',
         async () => await checkLoginStatus(),

--- a/linkedin/linkedin-playwright.js
+++ b/linkedin/linkedin-playwright.js
@@ -327,11 +327,15 @@ const extractYears = (obj) => {
 
     // Fallback to manual browser login if programmatic login failed
     if (!isAuthenticated) {
-      await page.requestManualAction(
+      const manualResult = await page.requestManualAction(
         'Complete any remaining verification, then click "Done".',
         async () => await checkLoginStatus(),
         { url: 'https://www.linkedin.com/login', interval: 2000 }
       );
+      if (manualResult.status === 'skipped') {
+        await page.setData('error', 'Login required but not available in automated mode.');
+        return;
+      }
 
       isAuthenticated = await checkApiAuth();
       if (!isAuthenticated) {

--- a/linkedin/linkedin-playwright.js
+++ b/linkedin/linkedin-playwright.js
@@ -197,7 +197,7 @@ const extractYears = (obj) => {
     const hasLoginForm = await page.evaluate(`!!document.querySelector('input[name="session_key"]')`);
 
     if (hasLoginForm) {
-      const { email, password } = await page.requestInput({
+      const credentialsResult = await page.requestData({
         message: "Log in to LinkedIn",
         schema: {
           type: "object",
@@ -208,6 +208,11 @@ const extractYears = (obj) => {
           required: ["email", "password"],
         },
       });
+      if (credentialsResult.status === 'skipped') {
+        await page.setData('error', 'Login credentials required but not available in automated mode.');
+        return;
+      }
+      const { email, password } = credentialsResult.data;
 
       await page.evaluate(`
         (() => {
@@ -248,7 +253,7 @@ const extractYears = (obj) => {
         window.location.href.includes('/checkpoint/')
       `);
       if (needs2fa) {
-        const { code } = await page.requestInput({
+        const tfaResult = await page.requestData({
           message: "Enter your LinkedIn verification code",
           schema: {
             type: "object",
@@ -256,6 +261,11 @@ const extractYears = (obj) => {
             required: ["code"],
           },
         });
+        if (tfaResult.status === 'skipped') {
+          await page.setData('error', 'Login credentials required but not available in automated mode.');
+          return;
+        }
+        const { code } = tfaResult.data;
         await page.evaluate(`
           (() => {
             const input = document.querySelector('input[name="pin"]') ||
@@ -315,18 +325,13 @@ const extractYears = (obj) => {
       }
     }
 
-    // Fallback to headed browser if programmatic login failed
+    // Fallback to manual browser login if programmatic login failed
     if (!isAuthenticated) {
-      const { headed } = await page.showBrowser('https://www.linkedin.com/login');
-      if (headed) {
-        await page.setData('status', 'Please complete login in the browser...');
-        await page.promptUser(
-          'Complete any remaining verification, then click "Done".',
-          async () => await checkLoginStatus(),
-          2000
-        );
-        await page.goHeadless();
-      }
+      await page.requestManualAction(
+        'Complete any remaining verification, then click "Done".',
+        async () => await checkLoginStatus(),
+        { url: 'https://www.linkedin.com/login', interval: 2000 }
+      );
 
       isAuthenticated = await checkApiAuth();
       if (!isAuthenticated) {

--- a/meta/instagram-playwright.js
+++ b/meta/instagram-playwright.js
@@ -207,7 +207,7 @@ const fetchWebInfo = async () => {
 
     // Fallback to manual browser login if programmatic login failed
     if (!loginSucceeded) {
-      await page.requestManualAction(
+      const manualResult = await page.requestManualAction(
         'Complete any remaining verification, then click "Done".',
         async () => {
           const info = await fetchWebInfo();
@@ -215,6 +215,10 @@ const fetchWebInfo = async () => {
         },
         { url: 'https://www.instagram.com/accounts/login/', interval: 2000 }
       );
+      if (manualResult.status === 'skipped') {
+        await page.setData('error', 'Login required but not available in automated mode.');
+        return;
+      }
 
       // Dismiss any remaining interstitials after headed browser login
       for (let dismissAttempt = 0; dismissAttempt < 3; dismissAttempt++) {

--- a/meta/instagram-playwright.js
+++ b/meta/instagram-playwright.js
@@ -207,6 +207,7 @@ const fetchWebInfo = async () => {
 
     // Fallback to manual browser login if programmatic login failed
     if (!loginSucceeded) {
+      await page.setData('status', 'Please complete login in the browser...');
       const manualResult = await page.requestManualAction(
         'Complete any remaining verification, then click "Done".',
         async () => {
@@ -217,7 +218,7 @@ const fetchWebInfo = async () => {
       );
       if (manualResult.status === 'skipped') {
         await page.setData('error', 'Login required but not available in automated mode.');
-        return;
+        return { error: 'Instagram login failed.' };
       }
 
       // Dismiss any remaining interstitials after headed browser login

--- a/meta/instagram-playwright.js
+++ b/meta/instagram-playwright.js
@@ -98,7 +98,7 @@ const fetchWebInfo = async () => {
     `);
 
     if (hasLoginForm) {
-      const { username: loginUser, password } = await page.requestInput({
+      const credentialsResult = await page.requestData({
         message: "Log in to Instagram",
         schema: {
           type: "object",
@@ -109,6 +109,11 @@ const fetchWebInfo = async () => {
           required: ["username", "password"],
         },
       });
+      if (credentialsResult.status === 'skipped') {
+        await page.setData('error', 'Login credentials required but not available in automated mode.');
+        return;
+      }
+      const { username: loginUser, password } = credentialsResult.data;
 
       await page.evaluate(`document.querySelector('input[name="username"]').value = ${JSON.stringify(loginUser)}`);
       await page.evaluate(`document.querySelector('input[name="username"]').dispatchEvent(new Event('input', {bubbles:true}))`);
@@ -125,7 +130,7 @@ const fetchWebInfo = async () => {
         !!document.querySelector('input[name="approvals_code"]')
       `);
       if (needs2fa) {
-        const { code } = await page.requestInput({
+        const tfaResult = await page.requestData({
           message: "Enter your Instagram security/verification code",
           schema: {
             type: "object",
@@ -133,6 +138,11 @@ const fetchWebInfo = async () => {
             required: ["code"],
           },
         });
+        if (tfaResult.status === 'skipped') {
+          await page.setData('error', 'Login credentials required but not available in automated mode.');
+          return;
+        }
+        const { code } = tfaResult.data;
         await page.evaluate(`
           (() => {
             const input = document.querySelector('input[name="verificationCode"]') ||
@@ -195,24 +205,16 @@ const fetchWebInfo = async () => {
     let newWebInfo = await fetchWebInfo();
     let loginSucceeded = !!(newWebInfo && newWebInfo.username);
 
-    // Fallback to headed browser if programmatic login failed
+    // Fallback to manual browser login if programmatic login failed
     if (!loginSucceeded) {
-      const { headed } = await page.showBrowser('https://www.instagram.com/accounts/login/');
-      if (headed) {
-        await page.setData('status', 'Please complete login in the browser...');
-        await page.promptUser(
-          'Complete any remaining verification, then click "Done".',
-          async () => {
-            const info = await fetchWebInfo();
-            return !!(info && info.username);
-          },
-          2000
-        );
-        await page.goHeadless();
-      } else {
-        await page.setData('error', 'Instagram login failed.');
-        return { error: 'Instagram login failed' };
-      }
+      await page.requestManualAction(
+        'Complete any remaining verification, then click "Done".',
+        async () => {
+          const info = await fetchWebInfo();
+          return !!(info && info.username);
+        },
+        { url: 'https://www.instagram.com/accounts/login/', interval: 2000 }
+      );
 
       // Dismiss any remaining interstitials after headed browser login
       for (let dismissAttempt = 0; dismissAttempt < 3; dismissAttempt++) {

--- a/openai/chatgpt-playwright.js
+++ b/openai/chatgpt-playwright.js
@@ -487,7 +487,7 @@ const fetchConversationBatch = async (accessToken, deviceId, convIds) => {
     // Fallback to headed browser if programmatic login failed
     // (needed for SSO flows: Google, Microsoft, Apple)
     if (!isLoggedIn) {
-      await page.requestManualAction(
+      const manualResult = await page.requestManualAction(
         'Complete login in the browser, then click "Done".',
         async () => {
           await dismissInterruptingDialogs();
@@ -495,6 +495,10 @@ const fetchConversationBatch = async (accessToken, deviceId, convIds) => {
         },
         { url: 'https://chatgpt.com/', interval: 2000 }
       );
+      if (manualResult.status === 'skipped') {
+        await page.setData('error', 'Login required but not available in automated mode.');
+        return;
+      }
     }
 
     await page.setData('status', 'Login completed');

--- a/openai/chatgpt-playwright.js
+++ b/openai/chatgpt-playwright.js
@@ -487,6 +487,7 @@ const fetchConversationBatch = async (accessToken, deviceId, convIds) => {
     // Fallback to headed browser if programmatic login failed
     // (needed for SSO flows: Google, Microsoft, Apple)
     if (!isLoggedIn) {
+      await page.setData('status', 'Please complete login in the browser...');
       const manualResult = await page.requestManualAction(
         'Complete login in the browser, then click "Done".',
         async () => {

--- a/openai/chatgpt-playwright.js
+++ b/openai/chatgpt-playwright.js
@@ -361,7 +361,7 @@ const fetchConversationBatch = async (accessToken, deviceId, convIds) => {
     `);
 
     if (hasEmailField) {
-      const { email } = await page.requestInput({
+      const emailResult = await page.requestData({
         message: "Log in to ChatGPT — enter your OpenAI account email",
         schema: {
           type: "object",
@@ -371,6 +371,11 @@ const fetchConversationBatch = async (accessToken, deviceId, convIds) => {
           required: ["email"],
         },
       });
+      if (emailResult.status === 'skipped') {
+        await page.setData('error', 'Login credentials required but not available in automated mode.');
+        return;
+      }
+      const { email } = emailResult.data;
 
       await page.evaluate(`
         (() => {
@@ -401,7 +406,7 @@ const fetchConversationBatch = async (accessToken, deviceId, convIds) => {
       `);
 
       if (hasPasswordField) {
-        const { password } = await page.requestInput({
+        const passwordResult = await page.requestData({
           message: "Enter your OpenAI account password",
           schema: {
             type: "object",
@@ -411,6 +416,11 @@ const fetchConversationBatch = async (accessToken, deviceId, convIds) => {
             required: ["password"],
           },
         });
+        if (passwordResult.status === 'skipped') {
+          await page.setData('error', 'Login credentials required but not available in automated mode.');
+          return;
+        }
+        const { password } = passwordResult.data;
 
         await page.evaluate(`
           (() => {
@@ -440,7 +450,7 @@ const fetchConversationBatch = async (accessToken, deviceId, convIds) => {
           !!document.querySelector('input[inputmode="numeric"]')
         `);
         if (needs2fa) {
-          const { code } = await page.requestInput({
+          const codeResult = await page.requestData({
             message: "Enter your OpenAI 2FA verification code",
             schema: {
               type: "object",
@@ -448,6 +458,11 @@ const fetchConversationBatch = async (accessToken, deviceId, convIds) => {
               required: ["code"],
             },
           });
+          if (codeResult.status === 'skipped') {
+            await page.setData('error', 'Login credentials required but not available in automated mode.');
+            return;
+          }
+          const { code } = codeResult.data;
           await page.evaluate(`
             (() => {
               const input = document.querySelector('input[name="code"]') ||
@@ -472,19 +487,14 @@ const fetchConversationBatch = async (accessToken, deviceId, convIds) => {
     // Fallback to headed browser if programmatic login failed
     // (needed for SSO flows: Google, Microsoft, Apple)
     if (!isLoggedIn) {
-      const { headed } = await page.showBrowser('https://chatgpt.com/');
-      if (headed) {
-        await page.setData('status', 'Please complete login in the browser (SSO or remaining verification)...');
-        await page.promptUser(
-          'Complete login in the browser, then click "Done".',
-          async () => {
-            await dismissInterruptingDialogs();
-            return await checkLoginStatus();
-          },
-          2000
-        );
-        await page.goHeadless();
-      }
+      await page.requestManualAction(
+        'Complete login in the browser, then click "Done".',
+        async () => {
+          await dismissInterruptingDialogs();
+          return await checkLoginStatus();
+        },
+        { url: 'https://chatgpt.com/', interval: 2000 }
+      );
     }
 
     await page.setData('status', 'Login completed');

--- a/oura/oura-playwright.js
+++ b/oura/oura-playwright.js
@@ -142,7 +142,7 @@ const fetchDailyDataChunked = async (startDate, endDate, chunkDays) => {
     `);
 
     if (hasLoginForm) {
-      const { email, password } = await page.requestInput({
+      const credResult = await page.requestData({
         message: "Log in to your Oura account",
         schema: {
           type: "object",
@@ -153,6 +153,11 @@ const fetchDailyDataChunked = async (startDate, endDate, chunkDays) => {
           required: ["email", "password"],
         },
       });
+      if (credResult.status === 'skipped') {
+        await page.setData('error', 'Login credentials required but not available in automated mode.');
+        return;
+      }
+      const { email, password } = credResult.data;
 
       await page.evaluate(`
         (() => {
@@ -188,19 +193,12 @@ const fetchDailyDataChunked = async (startDate, endDate, chunkDays) => {
 
     // Fallback to headed browser if programmatic login failed
     if (!isLoggedIn) {
-      const { headed } = await page.showBrowser('https://cloud.ouraring.com/user/sign-in');
-      if (headed) {
-        await page.setData('status', 'Please complete login in the browser...');
-        await page.promptUser(
-          'Complete any remaining verification, then click "Done".',
-          async () => await checkLoginStatus(),
-          2000,
-        );
-        await page.goHeadless();
-      } else {
-        await page.setData('error', 'Oura login failed.');
-        return;
-      }
+      await page.setData('status', 'Please complete login in the browser...');
+      await page.requestManualAction(
+        'Complete any remaining verification, then click "Done".',
+        async () => await checkLoginStatus(),
+        { url: 'https://cloud.ouraring.com/user/sign-in', interval: 2000 },
+      );
       isLoggedIn = await checkLoginStatus();
     }
 

--- a/oura/oura-playwright.js
+++ b/oura/oura-playwright.js
@@ -194,11 +194,15 @@ const fetchDailyDataChunked = async (startDate, endDate, chunkDays) => {
     // Fallback to headed browser if programmatic login failed
     if (!isLoggedIn) {
       await page.setData('status', 'Please complete login in the browser...');
-      await page.requestManualAction(
+      const manualResult = await page.requestManualAction(
         'Complete any remaining verification, then click "Done".',
         async () => await checkLoginStatus(),
         { url: 'https://cloud.ouraring.com/user/sign-in', interval: 2000 },
       );
+      if (manualResult.status === 'skipped') {
+        await page.setData('error', 'Login required but not available in automated mode.');
+        return;
+      }
       isLoggedIn = await checkLoginStatus();
     }
 

--- a/shopify/shop-playwright.js
+++ b/shopify/shop-playwright.js
@@ -450,6 +450,7 @@ const extractOrdersFromDOM = async () => {
 
     // Fallback to headed browser if programmatic login failed
     if (!isLoggedIn) {
+      await page.setData('status', 'Please complete login in the browser...');
       const manualResult = await page.requestManualAction(
         'Complete any remaining verification, then click "Done".',
         async () => await checkLoginStatus(),

--- a/shopify/shop-playwright.js
+++ b/shopify/shop-playwright.js
@@ -450,11 +450,15 @@ const extractOrdersFromDOM = async () => {
 
     // Fallback to headed browser if programmatic login failed
     if (!isLoggedIn) {
-      await page.requestManualAction(
+      const manualResult = await page.requestManualAction(
         'Complete any remaining verification, then click "Done".',
         async () => await checkLoginStatus(),
         { url: 'https://shop.app/account/order-history', interval: 2000 }
       );
+      if (manualResult.status === 'skipped') {
+        await page.setData('error', 'Login required but not available in automated mode.');
+        return;
+      }
       isLoggedIn = await checkLoginStatus();
     }
 

--- a/shopify/shop-playwright.js
+++ b/shopify/shop-playwright.js
@@ -326,7 +326,7 @@ const extractOrdersFromDOM = async () => {
     `);
 
     if (hasEmailField) {
-      const { email } = await page.requestInput({
+      const emailResult = await page.requestData({
         message: "Log in to Shop — enter your email address",
         schema: {
           type: "object",
@@ -336,6 +336,11 @@ const extractOrdersFromDOM = async () => {
           required: ["email"],
         },
       });
+      if (emailResult.status === 'skipped') {
+        await page.setData('error', 'Login credentials required but not available in automated mode.');
+        return;
+      }
+      const { email } = emailResult.data;
 
       await page.evaluate(`
         (() => {
@@ -365,7 +370,7 @@ const extractOrdersFromDOM = async () => {
       `);
 
       if (hasCodeField) {
-        const { code } = await page.requestInput({
+        const codeResult = await page.requestData({
           message: "Enter the verification code Shop sent to your email",
           schema: {
             type: "object",
@@ -373,6 +378,11 @@ const extractOrdersFromDOM = async () => {
             required: ["code"],
           },
         });
+        if (codeResult.status === 'skipped') {
+          await page.setData('error', 'Login credentials required but not available in automated mode.');
+          return;
+        }
+        const { code } = codeResult.data;
         await page.evaluate(`
           (() => {
             const input = document.querySelector('input[name="code"]') ||
@@ -400,7 +410,7 @@ const extractOrdersFromDOM = async () => {
         !!document.querySelector('input[type="password"]')
       `);
       if (hasPasswordField) {
-        const { password } = await page.requestInput({
+        const passwordResult = await page.requestData({
           message: "Enter your Shop/Shopify password",
           schema: {
             type: "object",
@@ -410,6 +420,11 @@ const extractOrdersFromDOM = async () => {
             required: ["password"],
           },
         });
+        if (passwordResult.status === 'skipped') {
+          await page.setData('error', 'Login credentials required but not available in automated mode.');
+          return;
+        }
+        const { password } = passwordResult.data;
         await page.evaluate(`
           (() => {
             const passwordInput = document.querySelector('input[type="password"]');
@@ -435,16 +450,11 @@ const extractOrdersFromDOM = async () => {
 
     // Fallback to headed browser if programmatic login failed
     if (!isLoggedIn) {
-      const { headed } = await page.showBrowser('https://shop.app/account/order-history');
-      if (headed) {
-        await page.setData('status', 'Please complete login in the browser...');
-        await page.promptUser(
-          'Complete any remaining verification, then click "Done".',
-          async () => await checkLoginStatus(),
-          2000
-        );
-        await page.goHeadless();
-      }
+      await page.requestManualAction(
+        'Complete any remaining verification, then click "Done".',
+        async () => await checkLoginStatus(),
+        { url: 'https://shop.app/account/order-history', interval: 2000 }
+      );
       isLoggedIn = await checkLoginStatus();
     }
 

--- a/skills/vana-connect/reference/PATTERNS.md
+++ b/skills/vana-connect/reference/PATTERNS.md
@@ -434,6 +434,57 @@ const checkLoginStatus = async () => {
 };
 ```
 
+### Authentication (recommended pattern):
+
+Use `requestData` for credentials and `requestManualAction` for manual browser login.
+Both return `{ status: 'success' | 'skipped' }` — the connector decides what to do with a skip.
+
+```javascript
+// 1. Check session cookies
+await page.goto('https://platform.com/');
+await page.sleep(3000);
+let isLoggedIn = await checkLoginStatus();
+
+if (!isLoggedIn) {
+  // 2. Try programmatic login with requestData
+  const result = await page.requestData({
+    message: 'Enter your Platform credentials',
+    schema: {
+      type: 'object',
+      properties: {
+        email: { type: 'string', title: 'Email' },
+        password: { type: 'string', title: 'Password' },
+      },
+      required: ['email', 'password'],
+    },
+  });
+
+  if (result.status === 'success') {
+    await performLogin(result.data.email, result.data.password);
+    isLoggedIn = await checkLoginStatus();
+  }
+
+  // 3. Fall back to manual browser login
+  if (!isLoggedIn) {
+    const manual = await page.requestManualAction(
+      'Complete login in the browser, then click "Done".',
+      async () => await checkLoginStatus(),
+      { url: 'https://platform.com/login' },
+    );
+    if (manual.status === 'skipped') {
+      await page.setData('error', 'Login required but not available in automated mode.');
+      return;
+    }
+    isLoggedIn = await checkLoginStatus();
+  }
+
+  if (!isLoggedIn) {
+    await page.setData('error', 'Login failed.');
+    return;
+  }
+}
+```
+
 ### Dismissing popups/modals:
 
 ```javascript

--- a/skills/vana-connect/templates/connector-script.js
+++ b/skills/vana-connect/templates/connector-script.js
@@ -112,9 +112,9 @@ const fetchApi = async (endpoint) => {
   let isLoggedIn = await checkLoginStatus();
 
   if (!isLoggedIn) {
-    // Try .env credentials first, fall back to requestInput
+    // Try .env credentials first, fall back to requestData
     if (!PLATFORM_LOGIN || !PLATFORM_PASSWORD) {
-      const creds = await page.requestInput({
+      const result = await page.requestData({
         message: 'Enter your {{PLATFORM_NAME}} credentials',
         schema: {
           type: 'object',
@@ -125,8 +125,12 @@ const fetchApi = async (endpoint) => {
           required: ['username', 'password']
         }
       });
-      PLATFORM_LOGIN = creds.username;
-      PLATFORM_PASSWORD = creds.password;
+      if (result.status === 'skipped') {
+        await page.setData('error', 'Login credentials required but not available in automated mode.');
+        return;
+      }
+      PLATFORM_LOGIN = result.data.username;
+      PLATFORM_PASSWORD = result.data.password;
     }
     await page.setData('status', 'Logging in...');
     await performLogin();
@@ -138,8 +142,21 @@ const fetchApi = async (endpoint) => {
       isLoggedIn = await checkLoginStatus();
     }
     if (!isLoggedIn) {
-      await page.setData('error', 'Automated login failed. Check credentials or login flow.');
-      return;
+      // Fall back to manual browser login
+      const manualResult = await page.requestManualAction(
+        'Complete login in the browser, then click "Done".',
+        async () => await checkLoginStatus(),
+        { url: '{{PLATFORM_URL}}' }
+      );
+      if (manualResult.status === 'skipped') {
+        await page.setData('error', 'Login failed. Manual browser login required but not available in automated mode.');
+        return;
+      }
+      isLoggedIn = await checkLoginStatus();
+      if (!isLoggedIn) {
+        await page.setData('error', 'Login failed after manual attempt.');
+        return;
+      }
     }
     await page.setData('status', 'Login successful');
   } else {

--- a/spotify/spotify-playwright.js
+++ b/spotify/spotify-playwright.js
@@ -347,7 +347,7 @@ const spClientFetch = async (path) => {
     `);
 
     if (hasLoginForm) {
-      const { username, password } = await page.requestInput({
+      const credResult = await page.requestData({
         message: "Log in to Spotify",
         schema: {
           type: "object",
@@ -358,6 +358,11 @@ const spClientFetch = async (path) => {
           required: ["username", "password"],
         },
       });
+      if (credResult.status === 'skipped') {
+        await page.setData('error', 'Login credentials required but not available in automated mode.');
+        return;
+      }
+      const { username, password } = credResult.data;
 
       await page.evaluate(`
         (() => {
@@ -394,7 +399,7 @@ const spClientFetch = async (path) => {
         window.location.href.includes('challenge')
       `);
       if (needsEmailCode) {
-        const { code } = await page.requestInput({
+        const codeResult = await page.requestData({
           message: "Enter the verification code sent to your email by Spotify",
           schema: {
             type: "object",
@@ -402,6 +407,11 @@ const spClientFetch = async (path) => {
             required: ["code"],
           },
         });
+        if (codeResult.status === 'skipped') {
+          await page.setData('error', 'Verification code required but not available in automated mode.');
+          return;
+        }
+        const { code } = codeResult.data;
         await page.evaluate(`
           (() => {
             const input = document.querySelector('input[name="code"]') ||
@@ -451,16 +461,12 @@ const spClientFetch = async (path) => {
 
     // Fallback to headed browser if programmatic login failed
     if (!loginOk) {
-      const { headed } = await page.showBrowser('https://accounts.spotify.com/en/login?continue=https%3A%2F%2Fopen.spotify.com%2F');
-      if (headed) {
-        await page.setData('status', 'Please complete login in the browser...');
-        await page.promptUser(
-          'Complete any remaining verification, then click "Done".',
-          async () => await checkLoginComplete(),
-          3000
-        );
-        await page.goHeadless();
-      }
+      await page.setData('status', 'Please complete login in the browser...');
+      await page.requestManualAction(
+        'Complete any remaining verification, then click "Done".',
+        async () => await checkLoginComplete(),
+        { url: 'https://accounts.spotify.com/en/login?continue=https%3A%2F%2Fopen.spotify.com%2F', interval: 3000 },
+      );
     }
 
     await page.setData('status', 'Login completed. Capturing session...');

--- a/spotify/spotify-playwright.js
+++ b/spotify/spotify-playwright.js
@@ -462,11 +462,15 @@ const spClientFetch = async (path) => {
     // Fallback to headed browser if programmatic login failed
     if (!loginOk) {
       await page.setData('status', 'Please complete login in the browser...');
-      await page.requestManualAction(
+      const manualResult = await page.requestManualAction(
         'Complete any remaining verification, then click "Done".',
         async () => await checkLoginComplete(),
         { url: 'https://accounts.spotify.com/en/login?continue=https%3A%2F%2Fopen.spotify.com%2F', interval: 3000 },
       );
+      if (manualResult.status === 'skipped') {
+        await page.setData('error', 'Login required but not available in automated mode.');
+        return;
+      }
     }
 
     await page.setData('status', 'Login completed. Capturing session...');

--- a/types/connector.d.ts
+++ b/types/connector.d.ts
@@ -49,12 +49,27 @@ export interface ProgressUpdate {
   count?: number;
 }
 
-/** Payload for page.requestInput() */
+/** Payload for page.requestInput() and page.requestData() */
 export interface RequestInputPayload {
   /** Human-readable message describing what data is needed */
   message: string;
   /** JSON Schema describing the expected response shape (optional) */
   schema?: Record<string, unknown>;
+}
+
+/** Result from page.requestData() or page.requestManualAction() */
+export type InteractionResult<T = Record<string, unknown>> =
+  | { status: 'success'; data: T }
+  | { status: 'skipped'; reason: 'no-input' };
+
+/** Options for page.requestManualAction() */
+export interface ManualActionOptions {
+  /** URL to navigate the headed browser to */
+  url?: string;
+  /** Polling interval in ms (default: 2000) */
+  interval?: number;
+  /** Automatically switch back to headless after action completes (default: true) */
+  autoGoHeadless?: boolean;
 }
 
 /**
@@ -70,9 +85,26 @@ export interface PageAPI {
   screenshot(): Promise<string>;
 
   /**
-   * Request data from the driver (e.g., login credentials, 2FA codes).
-   * The runner relays the request to the driver and resolves with the response.
-   * Throws if the driver sends an error (e.g., user cancelled).
+   * Request structured data from the user (credentials, 2FA codes, etc.).
+   * Returns { status: 'success', data } or { status: 'skipped', reason: 'no-input' }.
+   * Never throws for missing input — the connector decides what to do with a skip.
+   */
+  requestData(payload: RequestInputPayload): Promise<InteractionResult>;
+
+  /**
+   * Request the user to complete a manual action in a headed browser.
+   * Opens headed browser, polls checkFn until truthy, goes headless, returns.
+   * Returns { status: 'skipped', reason: 'no-input' } in --no-input mode.
+   */
+  requestManualAction(
+    message: string,
+    checkFn: () => Promise<unknown>,
+    options?: ManualActionOptions,
+  ): Promise<InteractionResult<void>>;
+
+  /**
+   * @deprecated Use requestData() instead — it returns a result object instead of
+   * throwing in --no-input mode, letting the connector handle the skip gracefully.
    */
   requestInput(payload: RequestInputPayload): Promise<Record<string, unknown>>;
 
@@ -89,17 +121,20 @@ export interface PageAPI {
   setProgress(update: ProgressUpdate): Promise<void>;
 
   /**
-   * Escalate to headed mode for live human interaction (e.g., interactive CAPTCHAs).
-   * Returns { headed: false } if the driver doesn't support headed mode.
+   * @deprecated Use requestManualAction() instead — it merges showBrowser +
+   * promptUser + goHeadless into one call with consistent skip semantics.
    */
   showBrowser(url?: string): Promise<ShowBrowserResult>;
 
-  /** Switch to headless mode. No-op if already headless. */
+  /**
+   * @deprecated Use requestManualAction({ autoGoHeadless: false }) if you need
+   * to control headless transitions manually.
+   */
   goHeadless(): Promise<void>;
 
   /**
-   * Poll a check function until it returns truthy.
-   * Sends WAITING_FOR_USER status to the host.
+   * @deprecated Use requestManualAction() instead — promptUser is always used
+   * with showBrowser + goHeadless, and requestManualAction handles all three.
    */
   promptUser(message: string, checkFn: () => Promise<unknown>, interval?: number): Promise<void>;
 

--- a/uber/uber-playwright.js
+++ b/uber/uber-playwright.js
@@ -232,7 +232,7 @@ const scrapeTripDetailsFromPage = async () => {
     `);
 
     if (hasEmailField) {
-      const { email } = await page.requestInput({
+      const emailResult = await page.requestData({
         message: "Log in to Uber — enter your email or phone number",
         schema: {
           type: "object",
@@ -242,6 +242,11 @@ const scrapeTripDetailsFromPage = async () => {
           required: ["email"],
         },
       });
+      if (emailResult.status === 'skipped') {
+        await page.setData('error', 'Login credentials required but not available in automated mode.');
+        return;
+      }
+      const { email } = emailResult.data;
 
       await page.evaluate(`
         (() => {
@@ -277,7 +282,7 @@ const scrapeTripDetailsFromPage = async () => {
       `);
 
       if (hasPasswordField) {
-        const { password } = await page.requestInput({
+        const passwordResult = await page.requestData({
           message: "Enter your Uber password",
           schema: {
             type: "object",
@@ -287,6 +292,11 @@ const scrapeTripDetailsFromPage = async () => {
             required: ["password"],
           },
         });
+        if (passwordResult.status === 'skipped') {
+          await page.setData('error', 'Login credentials required but not available in automated mode.');
+          return;
+        }
+        const { password } = passwordResult.data;
 
         await page.evaluate(`
           (() => {
@@ -319,7 +329,7 @@ const scrapeTripDetailsFromPage = async () => {
           !!document.querySelector('input[type="tel"]')
         `);
         if (hasOtpField) {
-          const { code } = await page.requestInput({
+          const otpResult = await page.requestData({
             message: "Enter the verification code Uber sent to your phone",
             schema: {
               type: "object",
@@ -327,6 +337,11 @@ const scrapeTripDetailsFromPage = async () => {
               required: ["code"],
             },
           });
+          if (otpResult.status === 'skipped') {
+            await page.setData('error', 'Login credentials required but not available in automated mode.');
+            return;
+          }
+          const { code } = otpResult.data;
           await page.evaluate(`
             (() => {
               const input = document.querySelector('input[name="otp"]') ||
@@ -360,7 +375,7 @@ const scrapeTripDetailsFromPage = async () => {
         !!document.querySelector('input[type="tel"]')
       `);
       if (needs2fa) {
-        const { code } = await page.requestInput({
+        const tfaResult = await page.requestData({
           message: "Enter your Uber 2FA verification code",
           schema: {
             type: "object",
@@ -368,6 +383,11 @@ const scrapeTripDetailsFromPage = async () => {
             required: ["code"],
           },
         });
+        if (tfaResult.status === 'skipped') {
+          await page.setData('error', 'Login credentials required but not available in automated mode.');
+          return;
+        }
+        const { code } = tfaResult.data;
         await page.evaluate(`
           (() => {
             const input = document.querySelector('input[name="otp"]') ||
@@ -418,18 +438,13 @@ const scrapeTripDetailsFromPage = async () => {
       isLoggedIn = await checkLoginStatus();
     }
 
-    // Fallback to headed browser if programmatic login failed
+    // Fallback to manual browser login if programmatic login failed
     if (!isLoggedIn) {
-      const { headed } = await page.showBrowser('https://auth.uber.com/v2/');
-      if (headed) {
-        await page.setData('status', 'Please complete login in the browser...');
-        await page.promptUser(
-          'Complete any remaining verification, then click "Done".',
-          async () => await checkLoginStatus(),
-          3000
-        );
-        await page.goHeadless();
-      }
+      await page.requestManualAction(
+        'Complete any remaining verification, then click "Done".',
+        async () => await checkLoginStatus(),
+        { url: 'https://auth.uber.com/v2/', interval: 3000 }
+      );
       isLoggedIn = await checkLoginStatus();
     }
 

--- a/uber/uber-playwright.js
+++ b/uber/uber-playwright.js
@@ -440,11 +440,15 @@ const scrapeTripDetailsFromPage = async () => {
 
     // Fallback to manual browser login if programmatic login failed
     if (!isLoggedIn) {
-      await page.requestManualAction(
+      const manualResult = await page.requestManualAction(
         'Complete any remaining verification, then click "Done".',
         async () => await checkLoginStatus(),
         { url: 'https://auth.uber.com/v2/', interval: 3000 }
       );
+      if (manualResult.status === 'skipped') {
+        await page.setData('error', 'Login required but not available in automated mode.');
+        return;
+      }
       isLoggedIn = await checkLoginStatus();
     }
 

--- a/uber/uber-playwright.js
+++ b/uber/uber-playwright.js
@@ -440,6 +440,7 @@ const scrapeTripDetailsFromPage = async () => {
 
     // Fallback to manual browser login if programmatic login failed
     if (!isLoggedIn) {
+      await page.setData('status', 'Please complete login in the browser...');
       const manualResult = await page.requestManualAction(
         'Complete any remaining verification, then click "Done".',
         async () => await checkLoginStatus(),


### PR DESCRIPTION
## Summary
- Update `types/connector.d.ts` with `InteractionResult<T>`, `ManualActionOptions`, new `requestData` and `requestManualAction` methods, and `@deprecated` annotations on old APIs
- Update connector template to use `requestData` + `requestManualAction` instead of `requestInput` + `showBrowser`/`promptUser`/`goHeadless`
- Add recommended authentication pattern to `PATTERNS.md`
- Migrate all 10 core connectors: oura, github, spotify, linkedin, instagram, uber, shopify, chatgpt, youtube, heb

## Context
Depends on vana-com/vana-connect#102 which adds `requestData` and `requestManualAction` to the runtime.

The old APIs have inconsistent `--no-input` semantics:
- `requestInput` throws
- `showBrowser` returns `{ headed: false }`
- `promptUser` silently no-ops

The new APIs both return `{ status: 'success' | 'skipped' }`, letting the connector decide what to do. See vana-com/vana-connect#102 for the full design rationale.

## Test plan
- [ ] Blocked on vana-com/vana-connect#102 merging first
- [ ] Run `npx vana collect chatgpt --no-input --json` — verify no `legacy-auth`, clean outcome
- [ ] Run `npx vana collect github --no-input --json` — verify `needs-input` or skip behavior
- [ ] Spot-check oura, spotify, uber connectors

🤖 Generated with [Claude Code](https://claude.com/claude-code)