### PR TITLE
fix: remove connectors/ prefix from registry file paths

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -11,8 +11,8 @@
       "status": "stable",
       "description": "Exports your email, memories, and all conversations from ChatGPT using Playwright browser automation.",
       "files": {
-        "script": "connectors/openai/chatgpt-playwright.js",
-        "metadata": "connectors/openai/chatgpt-playwright.json"
+        "script": "openai/chatgpt-playwright.js",
+        "metadata": "openai/chatgpt-playwright.json"
       },
       "checksums": {
         "script": "sha256:72518dd765ff2103a0ad7dd184a9efcfac359764fca1613714400e661b2fe73a",
@@ -27,8 +27,8 @@
       "status": "stable",
       "description": "Exports your GitHub profile, repositories, and starred repositories using Playwright browser automation.",
       "files": {
-        "script": "connectors/github/github-playwright.js",
-        "metadata": "connectors/github/github-playwright.json"
+        "script": "github/github-playwright.js",
+        "metadata": "github/github-playwright.json"
       },
       "checksums": {
         "script": "sha256:3e2db5798b75089694034915257c4d900a7a1892a8da4848fb2be6cbb957ac9f",
@@ -43,8 +43,8 @@
       "status": "stable",
       "description": "Exports your Instagram profile, posts, and ad interests using Playwright browser automation.",
       "files": {
-        "script": "connectors/meta/instagram-playwright.js",
-        "metadata": "connectors/meta/instagram-playwright.json"
+        "script": "meta/instagram-playwright.js",
+        "metadata": "meta/instagram-playwright.json"
       },
       "checksums": {
         "script": "sha256:aaae0f1c62f9e2f5738a77e4fc326dd5375503b89d09c26a32bcdd482757385b",
@@ -57,10 +57,10 @@
       "version": "1.0.0",
       "name": "Instagram Ads",
       "status": "beta",
-      "description": "Exports your Instagram ad interests — advertisers and ad topics.",
+      "description": "Exports your Instagram ad interests \u2014 advertisers and ad topics.",
       "files": {
-        "script": "connectors/meta/instagram-ads-playwright.js",
-        "metadata": "connectors/meta/instagram-ads-playwright.json"
+        "script": "meta/instagram-ads-playwright.js",
+        "metadata": "meta/instagram-ads-playwright.json"
       },
       "checksums": {
         "script": "sha256:ef759279f73e52a05b063cf8e6a6bceb63409039f35f529b342bc1af004c972d",
@@ -75,8 +75,8 @@
       "status": "stable",
       "description": "Exports your LinkedIn profile, experience, education, skills, languages, and connections using Playwright browser automation.",
       "files": {
-        "script": "connectors/linkedin/linkedin-playwright.js",
-        "metadata": "connectors/linkedin/linkedin-playwright.json"
+        "script": "linkedin/linkedin-playwright.js",
+        "metadata": "linkedin/linkedin-playwright.json"
       },
       "checksums": {
         "script": "sha256:351a1a6706903bfbd7055c332f8baa118faa1ccb556cf019005f77cde422480b",
@@ -91,8 +91,8 @@
       "status": "stable",
       "description": "Exports your Spotify library, playlists, listening history, and preferences using Playwright browser automation.",
       "files": {
-        "script": "connectors/spotify/spotify-playwright.js",
-        "metadata": "connectors/spotify/spotify-playwright.json"
+        "script": "spotify/spotify-playwright.js",
+        "metadata": "spotify/spotify-playwright.json"
       },
       "checksums": {
         "script": "sha256:35d879b28c1e3b2bb7c84e97985b8edb4e80dbd61d2dae17c969ad02ff5e3e37",
@@ -107,8 +107,8 @@
       "status": "beta",
       "description": "Exports your YouTube profile, subscriptions, playlists, playlist items, liked videos, watch later list, and recent watch history using Playwright browser automation.",
       "files": {
-        "script": "connectors/google/youtube-playwright.js",
-        "metadata": "connectors/google/youtube-playwright.json"
+        "script": "google/youtube-playwright.js",
+        "metadata": "google/youtube-playwright.json"
       },
       "checksums": {
         "script": "sha256:41edd09ec113ad7f9d09c9c0de76e40577087ab4600d2c8ccba4ca95c3f919c6",
@@ -123,8 +123,8 @@
       "status": "beta",
       "description": "Exports your Shop app order history using Playwright browser automation.",
       "files": {
-        "script": "connectors/shopify/shop-playwright.js",
-        "metadata": "connectors/shopify/shop-playwright.json"
+        "script": "shopify/shop-playwright.js",
+        "metadata": "shopify/shop-playwright.json"
       },
       "checksums": {
         "script": "sha256:d9364d7cbaf95fbf0e3130b9221195099b33afe3bb700f411d336e40a705d37f",
@@ -139,8 +139,8 @@
       "status": "stable",
       "description": "Exports your Oura Ring readiness scores, sleep data, and daily activity using Playwright browser automation.",
       "files": {
-        "script": "connectors/oura/oura-playwright.js",
-        "metadata": "connectors/oura/oura-playwright.json"
+        "script": "oura/oura-playwright.js",
+        "metadata": "oura/oura-playwright.json"
       },
       "checksums": {
         "script": "sha256:8b2d087055d9dcb6d21409caecc232b440efa53fd32f538299faaa8283dfd080",
@@ -155,14 +155,14 @@
       "status": "experimental",
       "description": "Exports your Whole Foods Market order history (via Amazon) and product nutrition data using Playwright browser automation.",
       "files": {
-        "script": "connectors/wholefoods/wholefoods-playwright.js",
-        "metadata": "connectors/wholefoods/wholefoods-playwright.json"
+        "script": "wholefoods/wholefoods-playwright.js",
+        "metadata": "wholefoods/wholefoods-playwright.json"
       },
       "checksums": {
         "script": "sha256:2ebb4426258b87a8e3699b9609c36ff69b03f050e747ed530c54ee1e7f84c59b",
         "metadata": "sha256:dde3a72e809762799120b08b70a6f17ed9fba320aa2bf1ee790b013626fee2c1"
       }
-    },  
+    },
     {
       "id": "steam-playwright",
       "company": "valve",
@@ -171,14 +171,14 @@
       "status": "experimental",
       "description": "Exports your Steam profile, game library with playtime stats, and friend list using the Steam Web API.",
       "files": {
-        "script": "connectors/valve/steam-playwright.js",
-        "metadata": "connectors/valve/steam-playwright.json"
+        "script": "valve/steam-playwright.js",
+        "metadata": "valve/steam-playwright.json"
       },
       "checksums": {
         "script": "sha256:6d81afd55a3769de991d7a096dcf4f16008f41cf60a42e141b1d4311e36e85af",
         "metadata": "sha256:f2cabb1d26193df8c12207ebdcd6e668c05cfc14a112264a73ac3f88fb5e2bec"
       }
-    },  
+    },
     {
       "id": "heb-playwright",
       "company": "HEB",
@@ -187,14 +187,14 @@
       "status": "experimental",
       "description": "Exports your H-E-B account profile, order history, and product nutrition data using Playwright browser automation.",
       "files": {
-        "script": "connectors/heb/heb-playwright.js",
-        "metadata": "connectors/heb/heb-playwright.json"
+        "script": "heb/heb-playwright.js",
+        "metadata": "heb/heb-playwright.json"
       },
       "checksums": {
         "script": "sha256:83919643aaebe8e59386acc2868fd89e1ac94dc3464e26f5afedb570e96a7b9f",
         "metadata": "sha256:d9fd648f70b2f34b148b8ce14f7e99f46fb2c118add2e168c1b7aca95d7dd122"
       }
-    },  
+    },
     {
       "id": "amazon-playwright",
       "company": "amazon",
@@ -203,8 +203,8 @@
       "status": "beta",
       "description": "Exports your Amazon order history and profile information using Playwright browser automation.",
       "files": {
-        "script": "connectors/amazon/amazon-playwright.js",
-        "metadata": "connectors/amazon/amazon-playwright.json"
+        "script": "amazon/amazon-playwright.js",
+        "metadata": "amazon/amazon-playwright.json"
       },
       "checksums": {
         "script": "sha256:4a318b3c3884661929d8625ec04fac57b9fcd0d7508b699a8a3c9eba758c8f0a",
@@ -219,8 +219,8 @@
       "status": "beta",
       "description": "Exports your Uber trip history and receipts using Playwright browser automation.",
       "files": {
-        "script": "connectors/uber/uber-playwright.js",
-        "metadata": "connectors/uber/uber-playwright.json"
+        "script": "uber/uber-playwright.js",
+        "metadata": "uber/uber-playwright.json"
       },
       "checksums": {
         "script": "sha256:5b10877fbcd4d3cba5393820dabcf90812bc901532789c4221025e8035bb224e",
@@ -235,8 +235,8 @@
       "status": "experimental",
       "description": "Exports your Claude conversations and projects from claude.ai using Playwright browser automation.",
       "files": {
-        "script": "connectors/anthropic/claude-playwright.js",
-        "metadata": "connectors/anthropic/claude-playwright.json"
+        "script": "anthropic/claude-playwright.js",
+        "metadata": "anthropic/claude-playwright.json"
       },
       "checksums": {
         "script": "sha256:4e070bc31afd210563db5c0ece547c9535f197b79b5b28951d87993c8538dafe",

--- a/scripts/schema-health-check.mjs
+++ b/scripts/schema-health-check.mjs
@@ -92,7 +92,7 @@ const baseScopeSet = new Set();
 const baseRegistry = readGitJson(baseRef, "registry.json");
 if (baseRegistry?.connectors) {
   for (const connector of baseRegistry.connectors) {
-    const metadata = readGitJson(baseRef, connector.files.metadata);
+    const metadata = readGitJson(baseRef, `connectors/${connector.files.metadata}`);
     if (metadata?.scopes) {
       for (const entry of metadata.scopes) {
         baseScopeSet.add(entry.scope);
@@ -114,7 +114,7 @@ const connectors = registry.connectors;
 const scopeToConnector = new Map();
 
 for (const connector of connectors) {
-  const metadataPath = join(REPO_ROOT, connector.files.metadata);
+  const metadataPath = join(REPO_ROOT, "connectors", connector.files.metadata);
   let metadata;
   try {
     metadata = await readJson(metadataPath);

--- a/scripts/test-connectors.cjs
+++ b/scripts/test-connectors.cjs
@@ -215,8 +215,8 @@ function extractDiagnostics(stdoutLines, stderrLines) {
 
 function loadMetadata(connectorEntry) {
   const metadataPath = connectorEntry.files.metadata
-    ? path.join(ROOT, connectorEntry.files.metadata)
-    : path.join(ROOT, connectorEntry.files.script).replace(/\.js$/, '.json');
+    ? path.join(CONNECTORS_DIR, connectorEntry.files.metadata)
+    : path.join(CONNECTORS_DIR, connectorEntry.files.script).replace(/\.js$/, '.json');
 
   if (!fs.existsSync(metadataPath)) {
     return { error: `Metadata file not found: ${metadataPath}` };
@@ -304,7 +304,7 @@ function runConnector(connectorEntry, opts) {
   const metadata = loaded.metadata;
 
   return new Promise((resolve) => {
-    const scriptPath = path.join(ROOT, connectorEntry.files.script);
+    const scriptPath = path.join(CONNECTORS_DIR, connectorEntry.files.script);
     const outputPath = path.join(RESULTS_DIR, `${connectorEntry.id}.json`);
     const startUrl = metadata.connectURL || 'about:blank';
 

--- a/scripts/test-connectors.test.cjs
+++ b/scripts/test-connectors.test.cjs
@@ -19,7 +19,7 @@ const RESULTS_DIR = path.join(ROOT, 'test-results');
 function loadMetadata(connectorId) {
   const entry = REGISTRY.connectors.find(c => c.id === connectorId);
   if (!entry) throw new Error(`Connector not in registry: ${connectorId}`);
-  const metadataPath = path.join(ROOT, entry.files.metadata);
+  const metadataPath = path.join(ROOT, 'connectors', entry.files.metadata);
   return JSON.parse(fs.readFileSync(metadataPath, 'utf-8'));
 }
 
@@ -120,7 +120,7 @@ describe('classifyOutcome', () => {
 describe('connector metadata', () => {
   for (const entry of REGISTRY.connectors) {
     it(`${entry.id}: metadata file exists and has scopes`, () => {
-      const metadataPath = path.join(ROOT, entry.files.metadata);
+      const metadataPath = path.join(ROOT, 'connectors', entry.files.metadata);
       assert.ok(fs.existsSync(metadataPath), `Missing: ${metadataPath}`);
       const metadata = JSON.parse(fs.readFileSync(metadataPath, 'utf-8'));
       assert.ok(metadata.scopes && metadata.scopes.length > 0, `${entry.id}: no scopes declared`);
@@ -131,7 +131,7 @@ describe('connector metadata', () => {
     });
 
     it(`${entry.id}: script file exists`, () => {
-      const scriptPath = path.join(ROOT, entry.files.script);
+      const scriptPath = path.join(ROOT, 'connectors', entry.files.script);
       assert.ok(fs.existsSync(scriptPath), `Missing: ${scriptPath}`);
     });
   }


### PR DESCRIPTION
## Summary

- PR #53 added a `connectors/` prefix to file paths in `registry.json` to make the smoke test harness work, but this broke `data-connect`'s `fetch-connectors.js` which already prepends its own `connectors/` directory — resulting in doubled paths like `connectors/connectors/openai/chatgpt-playwright.js`
- Reverts registry paths to relative form (e.g. `openai/chatgpt-playwright.js`)
- Updates `test-connectors.cjs`, `test-connectors.test.cjs`, and `schema-health-check.mjs` to prepend `connectors/` themselves

## Test plan

- [x] All 83 existing tests pass (`node --test scripts/test-connectors.test.cjs`)
- [ ] Merge, then re-release data-connect v0.7.49 to verify CI builds succeed