### PR TITLE
fix: include connectors/ directory in registry baseUrl

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1,7 +1,7 @@
 {
   "version": "2.0.0",
   "lastUpdated": "2026-03-29T00:00:00Z",
-  "baseUrl": "https://raw.githubusercontent.com/vana-com/data-connectors/main",
+  "baseUrl": "https://raw.githubusercontent.com/vana-com/data-connectors/main/connectors",
   "connectors": [
     {
       "id": "chatgpt-playwright",


### PR DESCRIPTION
## Summary

- Follows up on #57 — file paths were corrected to be relative (e.g. `openai/chatgpt-playwright.js`) but the `baseUrl` still pointed to the repo root
- data-connect's fetch-connectors constructs download URLs as `baseUrl + "/" + files.script`, so `baseUrl` needs to include `/connectors` to match the repo directory structure
- Without this fix, downloads 404: `https://raw.githubusercontent.com/.../main/openai/chatgpt-playwright.js`
- With this fix: `https://raw.githubusercontent.com/.../main/connectors/openai/chatgpt-playwright.js` ✓

## Test plan

- [x] Verified URL returns HTTP 200 with curl
- [ ] Merge, then re-trigger data-connect v0.7.49 release build