### PR TITLE
fix(instagram-ads): verify login completed before proceeding

### DIFF
--- a/connectors/meta/instagram-ads-playwright.js
+++ b/connectors/meta/instagram-ads-playwright.js
@@ -109,7 +109,13 @@ const checkLoginStatus = async () => {
       2000
     );
     await page.goHeadless();
-    isLoggedIn = true;
+    // Re-verify login completed — promptUser resolves on poll-predicate truth OR timeout,
+    // so the user may have closed the window without logging in. Don't trust the prompt alone.
+    isLoggedIn = await checkLoginStatus();
+    if (!isLoggedIn) {
+      await page.setData('error', 'Instagram login was not completed.');
+      return { error: 'Instagram login was not completed' };
+    }
   } else {
     await page.setData('status', 'Session active');
   }


### PR DESCRIPTION
## Summary

- The Instagram ads connector set `isLoggedIn = true` unconditionally after the headed-browser login prompt. `page.promptUser()` resolves on poll-predicate truth **or** on timeout, so a user who closed the window without logging in produced the same state as a successful login.
- The subsequent scrape ran against an unauthenticated session, returned empty ad data, and the run was logged as successful.
- Fix: re-run `checkLoginStatus()` after `goHeadless()`. If it returns false, surface an error via `page.setData('error', ...)` and return `{ error: '...' }`. Matches the pattern already used by the sibling `instagram-playwright.js` login flow (lines 215–216).

## Why now

Flagged in today's connector silent-failure audit (context-gateway / `daily-work/13-04-2026-connector-silent-failure-audit/01-audit-report.md`). The canonical ads flow is **less defensive** than the legacy `context-gateway/public/automations/instagram-headless.js`, which re-queried `webInfo?.username` after each login attempt. Since Monday's unification deploy replaces the legacy with this canonical script, landing this regression would actively make production behaviour worse.

This is the only fix from that audit I'm landing right now — the broader phase-error tracking work is blocked on runner-contract questions for @tnunamak and will come as a separate PR.

## Diff

```diff
     await page.goHeadless();
-    isLoggedIn = true;
+    // Re-verify login completed — promptUser resolves on poll-predicate truth OR timeout,
+    // so the user may have closed the window without logging in. Don't trust the prompt alone.
+    isLoggedIn = await checkLoginStatus();
+    if (!isLoggedIn) {
+      await page.setData('error', 'Instagram login was not completed.');
+      return { error: 'Instagram login was not completed' };
+    }
```

## Test plan

No automated test harness exists for these scripts in this repo (no `package.json`, no vitest/jest, only manual `test-connector.cjs`). Manual repro:

- [ ] Start the `instagram-ads` connector.
- [ ] When the headed browser opens, close it without logging in.
- [ ] **Before:** connector returns `{ 'instagram.ads': { advertisers: [], ad_topics: [], categories: [] }, ... }` with no error field — logged as a successful run.
- [ ] **After:** connector returns `{ error: 'Instagram login was not completed' }` and `page.setData('error', ...)` surfaces the message to the CG UI.
- [ ] Sanity: normal happy-path login still works (user completes login in headed browser, `checkLoginStatus()` returns true, scrape proceeds).

## Out of scope (intentional)

- Top-level `return { success: true, ... }` being unconditional — needs runner-contract decisions from @tnunamak before I touch it.
- Other audit findings in this file (empty-catch patterns, silent-empty-arrays on missing DOM selectors) — deferred to the broader fix PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)