### PR TITLE
fix(safeGoto): handle page-closed errors without killing the script

### DIFF
--- a/connectors/apple/icloud-notes-playwright.js
+++ b/connectors/apple/icloud-notes-playwright.js
@@ -52,8 +52,15 @@ const safeGoto = async (url, options = {}) => {
       console.error(
         `[icloud-notes] Navigation attempt ${attempt}/${attempts} failed for ${url}: ${message}`,
       );
+      if (/target.*closed|context.*closed|browser.*closed/i.test(message)) {
+        return false;
+      }
       if (attempt < attempts) {
-        await page.sleep(betweenMs);
+        try {
+          await page.sleep(betweenMs);
+        } catch {
+          return false;
+        }
       }
     }
   }

--- a/connectors/github/github-playwright.js
+++ b/connectors/github/github-playwright.js
@@ -47,8 +47,15 @@ const safeGoto = async (url, options = {}) => {
       console.error(
         `[github] Navigation attempt ${attempt}/${attempts} failed for ${url}: ${message}`,
       );
+      if (/target.*closed|context.*closed|browser.*closed/i.test(message)) {
+        return false;
+      }
       if (attempt < attempts) {
-        await page.sleep(betweenMs);
+        try {
+          await page.sleep(betweenMs);
+        } catch {
+          return false;
+        }
       }
     }
   }

--- a/connectors/meta/instagram-playwright.js
+++ b/connectors/meta/instagram-playwright.js
@@ -73,8 +73,19 @@ const safeGoto = async (url, options = {}) => {
       console.error(
         `[instagram] Navigation attempt ${attempt}/${attempts} failed for ${url}: ${message}`,
       );
+      // Once the underlying page/context/browser is closed, further
+      // retries cannot succeed — the target is gone. Bail out with
+      // `false` so the caller can skip the scope instead of letting
+      // the next page.sleep throw and kill the whole script.
+      if (/target.*closed|context.*closed|browser.*closed/i.test(message)) {
+        return false;
+      }
       if (attempt < attempts) {
-        await page.sleep(betweenMs);
+        try {
+          await page.sleep(betweenMs);
+        } catch {
+          return false;
+        }
       }
     }
   }

--- a/connectors/oura/oura-playwright.js
+++ b/connectors/oura/oura-playwright.js
@@ -52,8 +52,15 @@ const safeGoto = async (url, options = {}) => {
       console.error(
         `[oura] Navigation attempt ${attempt}/${attempts} failed for ${url}: ${message}`,
       );
+      if (/target.*closed|context.*closed|browser.*closed/i.test(message)) {
+        return false;
+      }
       if (attempt < attempts) {
-        await page.sleep(betweenMs);
+        try {
+          await page.sleep(betweenMs);
+        } catch {
+          return false;
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary

`safeGoto` promises callers it will return `false` on nav failure so they can skip a scope instead of killing the run. Two holes in that contract:

1. The retry `page.sleep(betweenMs)` between attempts is not in try/catch — if the page/context is already closed, the sleep throws and propagates out, killing the entire script with a misleading "page.waitForTimeout: Target page ... closed" error instead of a clean skip.
2. Once the target is closed, retries are wasted — there's no point looping three times.

## Fix

Applied to all four scripts sharing this helper (instagram, github, oura, icloud-notes):

- When the goto error indicates a closed target → `return false` immediately, skip the retry loop.
- Wrap the retry sleep in its own try/catch → return `false` if it throws too.

Caller behavior is unchanged on recoverable errors (transient timeouts, network blips).

## Context

Caught by [BUI-358](https://linear.app/vana-team/issue/BUI-358). Canary full mode for instagram was reporting the retry-sleep error instead of the original nav failure, which made it look like a `waitForTimeout` bug when the real issue is something closing the page mid-run (worker session timeout / anti-bot / etc — still under investigation). The misleading error made the root cause invisible.

## Test plan

- [ ] Re-run canary full mode after snapshot re-sync in context-gateway and confirm we see the actual first failure instead of a retry-sleep error
- [x] Diff is a pure refinement — existing recoverable-error path is untouched