### PR TITLE
fix: guard update-data-connect job until consumer scripts ship

### DIFF
--- a/.github/workflows/consumer-update-prs.yml
+++ b/.github/workflows/consumer-update-prs.yml
@@ -79,29 +79,46 @@ jobs:
           ref: main
           path: data-connect
 
+      - name: Check for required consumer scripts
+        id: scripts_check
+        working-directory: data-connect
+        run: |
+          if [ -f scripts/resolve-connectors.js ] && [ -f scripts/generate-platform-registry.js ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping update-data-connect: consumer scripts not yet on data-connect main. Remove this guard after data-connect PR #106 merges."
+          fi
+
       - uses: actions/setup-node@v4
+        if: steps.scripts_check.outputs.present == 'true'
         with:
           node-version: "20"
 
       - name: Install data-connect deps
+        if: steps.scripts_check.outputs.present == 'true'
         working-directory: data-connect
         run: npm install
 
       - name: Install local shared installer package
+        if: steps.scripts_check.outputs.present == 'true'
         working-directory: data-connect
         run: npm install --no-save ../data-connectors
 
       - name: Resolve connectors and regenerate platform registry
+        if: steps.scripts_check.outputs.present == 'true'
         working-directory: data-connect
         run: |
           node scripts/resolve-connectors.js --from-local ../data-connectors
           node scripts/generate-platform-registry.js
 
       - name: Run tests
+        if: steps.scripts_check.outputs.present == 'true'
         working-directory: data-connect
         run: npm test
 
       - name: Create pull request
+        if: steps.scripts_check.outputs.present == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.CONSUMER_PR_TOKEN }}


### PR DESCRIPTION
## Summary

The `update-data-connect` job in `.github/workflows/consumer-update-prs.yml` calls `scripts/resolve-connectors.js` and `scripts/generate-platform-registry.js` in `vana-com/data-connect`'s main branch. Those scripts are staged in [data-connect PR #106](https://github.com/vana-com/data-connect/pull/106) but have not yet merged, so any qualifying push to this repo's main will fail the job.

This PR adds a `scripts_check` step that probes for both scripts in the checked-out `data-connect/main`. When either is missing, the step emits a GitHub `::notice::` and all subsequent steps in the job are skipped via `if:` gating, so the job exits green. The `update-context-gateway` job is untouched.

## Why guard vs. remove the job

Per the connector distribution execution plan, the workflow is expected to light up for real once data-connect #106 merges. Removing and re-adding the job would lose history and require an extra PR to re-enable. Guarding is a one-line-condition add to each step and removes cleanly in one follow-up.

## Removal instructions

Once data-connect #106 merges and `scripts/resolve-connectors.js` + `scripts/generate-platform-registry.js` are on data-connect `main`:

- Delete the `Check for required consumer scripts` step.
- Remove the `if: steps.scripts_check.outputs.present == 'true'` condition from every subsequent step in `update-data-connect`.

## Test plan

- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/consumer-update-prs.yml'))"`).
- [ ] Real workflow run on a qualifying path change after merge will emit the notice and exit green. (Cannot be validated pre-merge without triggering the workflow on main.)

## Related

- Execution plan: `context-gateway/docs/260421-connector-distribution-execution-plan.md` (PR 0)
- data-connectors PR #69 (connector release contract tooling)
- data-connect PR #106 (migrate connector delivery to canonical artifacts)