### PR TITLE
feat(instagram): capture taken_at on posts

### DIFF
--- a/connectors/meta/instagram-playwright.js
+++ b/connectors/meta/instagram-playwright.js
@@ -1039,12 +1039,23 @@ const fetchWebInfo = async () => {
         id: liker.id || liker.pk || "",
       }));
 
-      return {
+      const post = {
         img_url: imgUrl,
         caption,
         num_of_likes: numOfLikes,
         who_liked: whoLiked,
       };
+
+      // Instagram v1 feed media nodes carry the capture time as `taken_at`
+      // (unix seconds). Only emit when present; never fabricate.
+      const takenAtRaw = node.taken_at ?? node.taken_at_timestamp;
+      if (typeof takenAtRaw === "number" && Number.isFinite(takenAtRaw)) {
+        // Values are in seconds; ms-scale values (>1e12) are passed through as-is.
+        const takenAtMs = takenAtRaw > 1e12 ? takenAtRaw : takenAtRaw * 1000;
+        post.taken_at = new Date(takenAtMs).toISOString();
+      }
+
+      return post;
     });
 
     if (wantsProfile) {

--- a/connectors/meta/schemas/instagram.posts.json
+++ b/connectors/meta/schemas/instagram.posts.json
@@ -15,6 +15,7 @@
             "img_url": { "type": "string" },
             "caption": { "type": "string" },
             "num_of_likes": { "type": "number" },
+            "taken_at": { "type": "string" },
             "who_liked": {
               "type": "array",
               "items": {


### PR DESCRIPTION
## What
Adds real per-post **capture dates** to Instagram posts:
- `instagram-playwright.js` — extract `taken_at` (`taken_at` / `taken_at_timestamp`) from the IG v1 feed media node, emit as ISO string.
- `schemas/instagram.posts.json` — add `taken_at: string` to the scope schema.

## Why
The **Memory timeline** needs real per-post dates. Without `taken_at`, every post lands on the collected-at timestamp and piles onto one day. This is the desktop/DataConnect path; the web/lite path (data-pipe Apify actor) maps the same field.

## ⚠️ Needs a maintainer step before deploy
- **Re-register the connector** (`register.cjs` → registry.json checksum + artifact). I did **not** include a registry.json change: `register.cjs` in my environment rewrote the entry inconsistently with `main` (dropped `sourceId/displayName/...`, changed `meta/`→`connectors/meta/` paths), so the checksum bump should be done with the correct tooling/setup.
- **Register the updated schema to Context Gateway** so PS accepts `taken_at` (the scope is strict). This is a prerequisite for posts to persist with dates from either path.

## Scope
IG `taken_at` only — branched cleanly off `main` (Slack is separate in #77).