### PR TITLE
feat(chatgpt): fetch via /conversations/batch (bypass per-id 429)

### DIFF
--- a/connectors/openai/__tests__/chatgpt-resume.browser.test.cjs
+++ b/connectors/openai/__tests__/chatgpt-resume.browser.test.cjs
@@ -283,6 +283,32 @@ function summarize(result) {
     console.log('  ✓ run2 classifies as success');
   }
 
+  // ── RUN 3: one conversation (c7) is broken server-side — 500s on the batch
+  //    (omitted) AND on the per-id fallback. It must be SKIPPED after a bounded
+  //    number of retries so the run still COMPLETES (not stuck partial). ──
+  const dir3 = fs.mkdtempSync(path.join(os.tmpdir(), 'chatgpt-skip-'));
+  const plan3 = { list, hits: {}, batchHits: {}, detail: (id) => (id === 'c7' ? { status: 500 } : { status: 200 }) };
+  const run3 = await runConnectorOnce(dir3, plan3);
+  const r3 = run3.captured.results[run3.captured.results.length - 1];
+  console.log('RUN3', JSON.stringify(summarize(r3)));
+
+  assert.strictEqual(r3['chatgpt.conversations'].total, 11, 'run3 should save the 11 healthy conversations');
+  assert(!run3.ckpt.ids.includes('c7'), 'the broken c7 must NOT be saved');
+  assert.strictEqual(r3.exportSummary.details.skipped, 1, 'run3 should report 1 skipped conversation');
+  assert.strictEqual(r3.exportSummary.details.pending, 0, 'skipped convs must NOT count as pending');
+  assert.strictEqual(r3.errors.length, 0, 'a skipped-but-complete run emits no degraded error');
+  // The broken conv is retried a BOUNDED number of times, then skipped (not hammered).
+  assert((plan3.hits['c7'] || 0) <= 3, `c7 should be skipped after <=3 fallback attempts (got ${plan3.hits['c7']})`);
+  assert.strictEqual(run3.ckpt.meta.fullSyncDone, true, 'run3 should mark the sync complete despite the skip');
+  console.log(`  ✓ run3 skipped broken c7 after ${plan3.hits['c7']} attempts, completed 11/12 (0 pending)`);
+
+  if (classifier) {
+    const c3 = classifier.classify(classifier.normalize(r3, { requestedScopes: r3.requestedScopes }), { expectedRequestedScopes: r3.requestedScopes });
+    assert.strictEqual(c3.outcome, 'success', `run3 must classify success (skip doesn't degrade), got ${c3.outcome} (${c3.debug || ''})`);
+    console.log('  ✓ run3 classifies as success → skip does not mark the run incomplete');
+  }
+  fs.rmSync(dir3, { recursive: true, force: true });
+
   fs.rmSync(userDataDir, { recursive: true, force: true });
   console.log('\nALL BROWSER RESUME TESTS PASSED');
 })().catch((err) => {

--- a/connectors/openai/__tests__/chatgpt-resume.browser.test.cjs
+++ b/connectors/openai/__tests__/chatgpt-resume.browser.test.cjs
@@ -4,9 +4,10 @@
  *
  * Runs the ACTUAL connector script (chatgpt-playwright.js) against a real
  * Chromium, with a mock `page` API and Playwright route mocks standing in for
- * chatgpt.com. No OpenAI traffic. This reproduces the production failure
- * (a 429 storm — 2410/2484 conversations rate limited) at small scale and
- * proves:
+ * chatgpt.com. No OpenAI traffic. The connector fetches via the bulk
+ * /conversations/batch endpoint and falls back to the per-id GET for ids the
+ * batch omits; this test models that (batch returns the reachable convs, omits
+ * the rest, and the per-id fallback 429s — the throttle storm) and proves:
  *
  *   1. Rate-limited conversations are NOT emitted as empty successes.
  *   2. Whatever was fetched is checkpointed to IndexedDB and survives a full
@@ -107,6 +108,24 @@ async function installRoutes(context, plan) {
         body: JSON.stringify({ memories: [{ id: 'mem1', content: 'remember the demo', created_at: 't0', type: 'memory' }] }),
       });
     }
+    // Bulk endpoint — the connector's primary fetch path. Returns a JSON ARRAY of
+    // full conversations. Mirrors real behavior: a conversation whose verdict isn't
+    // 200 is simply OMITTED from the array (e.g. oversized/broken), which forces the
+    // connector to fall back to a single-conversation GET for that id. (Checked
+    // before the generic /conversations list route, which it is a substring of.)
+    if (url.includes('/backend-api/conversations/batch')) {
+      let ids = [];
+      try { ids = (JSON.parse(route.request().postData() || '{}').conversation_ids) || []; } catch (_) {}
+      if (plan.batchThrottle && plan.batchThrottle(ids)) {
+        return route.fulfill({ status: 429, contentType: 'application/json', body: JSON.stringify({ detail: 'too many requests' }) });
+      }
+      const arr = [];
+      for (const id of ids) {
+        plan.batchHits[id] = (plan.batchHits[id] || 0) + 1;
+        if (plan.detail(id).status === 200) arr.push({ id, ...convPayload(id) });
+      }
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(arr) });
+    }
     if (url.includes('/backend-api/conversations')) {
       const u = new URL(url);
       const offset = Number(u.searchParams.get('offset')) || 0;
@@ -114,6 +133,7 @@ async function installRoutes(context, plan) {
       const items = plan.list.slice(offset, offset + limit);
       return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ items, total: plan.list.length }) });
     }
+    // Per-conversation GET — now only the FALLBACK path for ids the batch omitted.
     const m = url.match(/\/backend-api\/conversation\/([^/?]+)/);
     if (m) {
       const id = m[1];
@@ -189,10 +209,12 @@ function summarize(result) {
   const N = 12;
   const list = makeList(N);
 
-  // ── RUN 1: rate-limit storm. c1–c4 succeed; c5–c12 always 429. ──
+  // ── RUN 1: c1–c4 come back in the batch; c5–c12 are omitted from the batch
+  //    and then 429 on the per-id fallback (the throttle storm). ──
   const plan1 = {
     list,
-    hits: {},
+    hits: {},       // per-id GET (fallback) hits
+    batchHits: {},  // /conversations/batch hits
     detail: (id) => {
       const n = Number(id.slice(1));
       return n <= 4 ? { status: 200 } : { status: 429, retryAfter: 1 };
@@ -212,10 +234,18 @@ function summarize(result) {
     'run1 must report the shortfall via errors[] (degraded), not silently');
   // No empty-success pollution: checkpoint holds only the 4 real ones.
   assert.deepStrictEqual(run1.ckpt.ids, ['c1', 'c2', 'c3', 'c4'], 'only fetched convs are checkpointed (no empty c5–c12)');
+  // The batch path is actually exercised: c1–c4 came back via /conversations/batch,
+  // NOT via the per-id fallback.
+  for (const id of ['c1', 'c2', 'c3', 'c4']) {
+    assert(plan1.batchHits[id], `${id} should be fetched via /conversations/batch`);
+    assert(!plan1.hits[id], `${id} should NOT need the per-id fallback`);
+  }
+  // The throttled ones fell through to the fallback (omitted from batch → per-id GET → 429).
+  assert(plan1.hits['c5'], 'omitted c5 must hit the per-id fallback');
   // Patient mode must converge/defer, not hammer every conv unboundedly.
   const totalDetailHits1 = Object.values(plan1.hits).reduce((a, b) => a + b, 0);
-  assert(totalDetailHits1 < N * 5, `should cap request volume when throttled (got ${totalDetailHits1} detail hits)`);
-  console.log(`  ✓ run1 partial-saved 4/12, ${totalDetailHits1} detail requests (no storm), reported degraded`);
+  assert(totalDetailHits1 < N * 5, `should cap request volume when throttled (got ${totalDetailHits1} fallback hits)`);
+  console.log(`  ✓ run1 partial-saved 4/12 via batch, ${totalDetailHits1} fallback requests (no storm), reported degraded`);
 
   if (classifier) {
     const c1 = classifier.classify(classifier.normalize(r1, { requestedScopes: r1.requestedScopes }), { expectedRequestedScopes: r1.requestedScopes });
@@ -223,8 +253,8 @@ function summarize(result) {
     console.log('  ✓ run1 classifies as partial → data IS delivered');
   }
 
-  // ── RUN 2: same profile, recovery. Everything returns 200 now. ──
-  const plan2 = { list, hits: {}, detail: () => ({ status: 200 }) };
+  // ── RUN 2: same profile, recovery. Everything returns 200 now (via batch). ──
+  const plan2 = { list, hits: {}, batchHits: {}, detail: () => ({ status: 200 }) };
   const run2 = await runConnectorOnce(userDataDir, plan2);
   const r2 = run2.captured.results[run2.captured.results.length - 1];
   console.log('RUN2', JSON.stringify(summarize(r2)));
@@ -234,9 +264,14 @@ function summarize(result) {
   assert.strictEqual(r2.exportSummary.details.newlyFetched, 8, 'run2 should fetch only the 8 missing');
   assert.strictEqual(r2.exportSummary.details.pending, 0, 'run2 should have nothing pending');
   assert.strictEqual(r2.errors.length, 0, 'run2 should have no errors');
-  // Proof of "no redundant work": the 4 already-saved convs are NOT re-requested.
+  // Proof of "no redundant work": the 4 already-saved convs are NOT re-requested,
+  // via the batch path OR the per-id fallback.
   for (const id of ['c1', 'c2', 'c3', 'c4']) {
-    assert(!plan2.hits[id], `run2 must NOT re-fetch already-saved ${id}`);
+    assert(!plan2.hits[id] && !plan2.batchHits[id], `run2 must NOT re-fetch already-saved ${id}`);
+  }
+  // The 8 missing convs were recovered via the batch endpoint (not the per-id path).
+  for (const id of ['c5', 'c12']) {
+    assert(plan2.batchHits[id], `run2 should refetch ${id} via /conversations/batch`);
   }
   assert.strictEqual(run2.ckpt.ids.length, 12, 'checkpoint should now hold all 12');
   assert.strictEqual(run2.ckpt.meta.fullSyncDone, true, 'run2 should mark the sync complete');

--- a/connectors/openai/chatgpt-playwright.js
+++ b/connectors/openai/chatgpt-playwright.js
@@ -50,6 +50,7 @@ const MIN_CONCURRENCY = 1;
 const BASE_BATCH_DELAY_MS = 700;   // polite pacing between healthy batches
 const MAX_BATCH_DELAY_MS = 8000;
 const MAX_ATTEMPTS = 8;            // per-conversation retry budget for non-throttle errors (5xx/network)
+const SERVER_ERROR_MAX_ATTEMPTS = 3; // after this many 5xx on one conversation, skip it (server-side broken)
 const CONV_FETCH_TIMEOUT_MS = 30000;
 const FLUSH_EVERY_CONVS = 25;      // incremental host flush cadence (by new convs)
 const FLUSH_INTERVAL_MS = 15000;   // …or by time
@@ -598,6 +599,7 @@ const buildResult = (requestedScopes, convMap, memories, telemetry) => {
         newlyFetched: telemetry.newlyFetched || 0,
         resumedFromCheckpoint: telemetry.resumed || 0,
         pending,
+        skipped: telemetry.skipped || 0,   // conversations that 5xx server-side (unfetchable); excluded from pending
         totalConversations: telemetry.totalConversations || conversations.length,
         statusCounts: telemetry.statusCounts || {},
         stoppedReason: telemetry.stoppedReason || null,
@@ -869,6 +871,7 @@ const buildResult = (requestedScopes, convMap, memories, telemetry) => {
     memoriesFailed: false,
     authFailed: false,
     stoppedReason: null,
+    skipped: 0,         // conversations dropped after a persistent server error (5xx)
   };
   const bumpStatus = (s) => {
     const key = String(s);
@@ -986,6 +989,7 @@ const buildResult = (requestedScopes, convMap, memories, telemetry) => {
   // Step 3: Adaptive, resumable conversation download.
   const runStart = Date.now();
   const queue = work.slice();
+  const skipped = new Set();        // conv ids dropped after a persistent 5xx (server-side broken)
   let concurrency = START_CONCURRENCY;
   let batchDelay = BASE_BATCH_DELAY_MS;
   let patientWaitMs = PATIENT_BACKOFF_START_MS;  // grows while throttled, resets on recovery
@@ -1002,7 +1006,8 @@ const buildResult = (requestedScopes, convMap, memories, telemetry) => {
       await ckptPutBatch(toWrite, memories, null).catch(() => {});
     }
     if (force || convsSinceFlush >= FLUSH_EVERY_CONVS || Date.now() - lastFlush >= FLUSH_INTERVAL_MS) {
-      telemetry.pending = queue.length + work.filter(w => w.attempts >= MAX_ATTEMPTS && !convMap.has(w.id)).length;
+      telemetry.skipped = skipped.size;
+      telemetry.pending = queue.length + work.filter(w => w.attempts >= MAX_ATTEMPTS && !convMap.has(w.id) && !skipped.has(w.id)).length;
       const partial = buildResult(requestedScopes, convMap, memories, telemetry);
       await page.setData('result', partial);   // host persists + delivers progressively
       convsSinceFlush = 0;
@@ -1043,7 +1048,17 @@ const buildResult = (requestedScopes, convMap, memories, telemetry) => {
       } else {
         // 5xx / network / timeout — retry with budget.
         item.attempts++;
-        if (item.attempts < MAX_ATTEMPTS) queue.push(item);
+        const isServerError = r.status >= 500 && r.status < 600;
+        if (isServerError && item.attempts >= SERVER_ERROR_MAX_ATTEMPTS) {
+          // Persistent server error: this conversation is broken server-side
+          // (it 5xx's on both batch and the per-id fallback — and even on delete).
+          // Skip it terminally so the run can COMPLETE instead of being stuck
+          // "partial" forever. Recorded as skipped (telemetry), not silently lost.
+          skipped.add(item.id);
+        } else if (item.attempts < MAX_ATTEMPTS) {
+          queue.push(item);
+        }
+        // else: exhausted network/timeout (status 0) — left out; a future run retries.
       }
     }
 
@@ -1109,7 +1124,10 @@ const buildResult = (requestedScopes, convMap, memories, telemetry) => {
 
   // Final checkpoint write + classification.
   await flush(true);
-  telemetry.pending = Math.max(0, telemetry.totalConversations - convMap.size);
+  telemetry.skipped = skipped.size;
+  // Skipped (persistently-broken 5xx) conversations are NOT counted as pending —
+  // they're unfetchable by any means, so the run is as complete as it can be.
+  telemetry.pending = Math.max(0, telemetry.totalConversations - convMap.size - skipped.size);
 
   // Mark a full sync complete only when nothing is outstanding.
   if (telemetry.pending === 0 && !telemetry.authFailed) {
@@ -1124,7 +1142,7 @@ const buildResult = (requestedScopes, convMap, memories, telemetry) => {
   const totalMessages = result.exportSummary.details.messages;
   const pendingSuffix = telemetry.pending > 0
     ? ` — ${telemetry.pending} still pending (will resume next run)`
-    : '';
+    : (skipped.size > 0 ? ` — ${skipped.size} skipped (broken server-side)` : '');
   await page.setProgress({
     phase: { step: 3, total: 3, label: 'Downloading conversations' },
     message: `Saved ${convMap.size}/${telemetry.totalConversations} conversations${pendingSuffix}`,

--- a/connectors/openai/chatgpt-playwright.js
+++ b/connectors/openai/chatgpt-playwright.js
@@ -41,8 +41,11 @@
 const CKPT_DB = 'vana_chatgpt_ckpt';
 const CKPT_FORMAT = 1;
 
-const START_CONCURRENCY = 2;       // conservative cold start
-const MAX_CONCURRENCY = 4;         // ceiling even when healthy
+// "Concurrency" now sizes the /conversations/batch request (ids per POST). The
+// server caps conversation_ids at 10, so 10 is the healthy ceiling = one batch
+// call per loop. MIN drops us to 1-per-call only if the batch endpoint ever 429s.
+const START_CONCURRENCY = 10;      // a full batch from the start — batch endpoint isn't throttled
+const MAX_CONCURRENCY = 10;        // server hard cap on conversation_ids per request
 const MIN_CONCURRENCY = 1;
 const BASE_BATCH_DELAY_MS = 700;   // polite pacing between healthy batches
 const MAX_BATCH_DELAY_MS = 8000;
@@ -365,14 +368,21 @@ const fetchConversationsPage = async (accessToken, deviceId, offset, limit) => {
   return result || { ok: false, status: 0 };
 };
 
-// Fetch a batch of conversation details in parallel (inside browser via Promise.all).
-// Each entry: { id, ok, status, retryAfter, title?, create_time?, update_time?, messages? }.
+// Fetch conversation details in bulk via the /conversations/batch endpoint
+// (POST, up to 10 ids per request). Unlike the per-conversation GET
+// (backend-api/conversation/{id}), this endpoint returns full conversation
+// content WITHOUT the brutal per-conversation rate limit — it's the path the
+// iOS/macOS ChatGPT apps use, which is why they never hit the 429 wall the web
+// client does. We chunk the caller's ids into groups of 10 and apply the same
+// message-tree walk to each returned conversation. Same return contract as before:
+// each entry { id, ok, status, retryAfter?, rl?, title?, create_time?, update_time?, messages? }.
 const fetchConversationBatch = async (accessToken, deviceId, convIds) => {
   const result = await page.evaluate(`
     (async () => {
       const token = ${JSON.stringify(accessToken)};
       const device = ${JSON.stringify(deviceId)};
       const ids = ${JSON.stringify(convIds)};
+      const BATCH_MAX = 10;  // server caps conversation_ids at 10 (422 above that)
 
       const parseRetryAfter = (resp) => {
         const h = resp.headers && resp.headers.get ? resp.headers.get('retry-after') : null;
@@ -384,7 +394,59 @@ const fetchConversationBatch = async (accessToken, deviceId, convIds) => {
         return null;
       };
 
-      const fetchOne = async (convId) => {
+      // Walk the message tree along the path to current_node (active branch).
+      const walkMessages = (data) => {
+        const mapping = data.mapping || {};
+        const currentNode = data.current_node;
+
+        let rootId = null;
+        for (const [nodeId, node] of Object.entries(mapping)) {
+          if (!node.parent || !mapping[node.parent]) { rootId = nodeId; break; }
+        }
+
+        const ancestorsOfCurrent = new Set();
+        let walkUp = currentNode;
+        while (walkUp && mapping[walkUp]) {
+          ancestorsOfCurrent.add(walkUp);
+          walkUp = mapping[walkUp].parent;
+        }
+
+        const messages = [];
+        let cursor = rootId;
+        while (cursor && mapping[cursor]) {
+          const node = mapping[cursor];
+          if (node.message) {
+            const msg = node.message;
+            const role = msg.author?.role;
+            const contentType = msg.content?.content_type;
+            if ((role === 'user' || role === 'assistant') &&
+                (contentType === 'text' || contentType === 'multimodal_text')) {
+              const textParts = (msg.content?.parts || []).filter(p => typeof p === 'string').join('\\n');
+              if (textParts.length > 0) {
+                messages.push({
+                  id: msg.id, role, content: textParts, content_type: contentType,
+                  create_time: msg.create_time ? new Date(msg.create_time * 1000).toISOString() : null,
+                  model: msg.metadata?.model_slug || null,
+                });
+              }
+            }
+          }
+          const children = node.children || [];
+          let nextCursor = null;
+          for (const childId of children) {
+            if (ancestorsOfCurrent.has(childId)) { nextCursor = childId; break; }
+          }
+          if (!nextCursor && children.length > 0) nextCursor = children[children.length - 1];
+          cursor = nextCursor;
+        }
+        return messages;
+      };
+
+      // Single-conversation fallback (mirrors the app's "fetch via remote ID batch
+      // fallback"): batch occasionally omits a conversation (e.g. oversized), so we
+      // fetch those individually. This path IS subject to the per-id rate limit, but
+      // it only runs for the rare omitted conversation, and a 429 just requeues it.
+      const fetchOneFallback = async (convId) => {
         try {
           const controller = new AbortController();
           const timeout = setTimeout(() => controller.abort(), ${CONV_FETCH_TIMEOUT_MS});
@@ -402,59 +464,45 @@ const fetchConversationBatch = async (accessToken, deviceId, convIds) => {
             return { id: convId, ok: false, status: response.status, retryAfter: parseRetryAfter(response), rl };
           }
           const data = await response.json();
-
-          // Walk the message tree along the path to current_node.
-          const mapping = data.mapping || {};
-          const currentNode = data.current_node;
-
-          let rootId = null;
-          for (const [nodeId, node] of Object.entries(mapping)) {
-            if (!node.parent || !mapping[node.parent]) { rootId = nodeId; break; }
-          }
-
-          const ancestorsOfCurrent = new Set();
-          let walkUp = currentNode;
-          while (walkUp && mapping[walkUp]) {
-            ancestorsOfCurrent.add(walkUp);
-            walkUp = mapping[walkUp].parent;
-          }
-
-          const messages = [];
-          let cursor = rootId;
-          while (cursor && mapping[cursor]) {
-            const node = mapping[cursor];
-            if (node.message) {
-              const msg = node.message;
-              const role = msg.author?.role;
-              const contentType = msg.content?.content_type;
-              if ((role === 'user' || role === 'assistant') &&
-                  (contentType === 'text' || contentType === 'multimodal_text')) {
-                const textParts = (msg.content?.parts || []).filter(p => typeof p === 'string').join('\\n');
-                if (textParts.length > 0) {
-                  messages.push({
-                    id: msg.id, role, content: textParts, content_type: contentType,
-                    create_time: msg.create_time ? new Date(msg.create_time * 1000).toISOString() : null,
-                    model: msg.metadata?.model_slug || null,
-                  });
-                }
-              }
-            }
-            const children = node.children || [];
-            let nextCursor = null;
-            for (const childId of children) {
-              if (ancestorsOfCurrent.has(childId)) { nextCursor = childId; break; }
-            }
-            if (!nextCursor && children.length > 0) nextCursor = children[children.length - 1];
-            cursor = nextCursor;
-          }
-
-          return { id: convId, ok: true, status: 200, title: data.title, create_time: data.create_time, update_time: data.update_time, messages };
+          return { id: convId, ok: true, status: 200, title: data.title, create_time: data.create_time, update_time: data.update_time, messages: walkMessages(data) };
         } catch (err) {
           return { id: convId, ok: false, status: 0, error: err.message };
         }
       };
 
-      return await Promise.all(ids.map(id => fetchOne(id)));
+      const out = [];
+      for (let i = 0; i < ids.length; i += BATCH_MAX) {
+        const chunk = ids.slice(i, i + BATCH_MAX);
+        try {
+          const controller = new AbortController();
+          const timeout = setTimeout(() => controller.abort(), ${CONV_FETCH_TIMEOUT_MS});
+          const response = await fetch(
+            "https://chatgpt.com/backend-api/conversations/batch",
+            { headers: { accept: "*/*", authorization: "Bearer " + token, "oai-device-id": device, "oai-language": "en-US", "content-type": "application/json" },
+              method: "POST", credentials: "include", body: JSON.stringify({ conversation_ids: chunk }), signal: controller.signal }
+          );
+          clearTimeout(timeout);
+          if (!response.ok) {
+            const rl = {};
+            for (const [k, v] of response.headers.entries()) {
+              if (/retry-after|rate.?limit|reset|remaining/i.test(k)) rl[k] = v;
+            }
+            const retryAfter = parseRetryAfter(response);
+            for (const id of chunk) out.push({ id, ok: false, status: response.status, retryAfter, rl });
+            continue;
+          }
+          const arr = await response.json();
+          const byId = new Map((Array.isArray(arr) ? arr : []).map(c => [c.id, c]));
+          for (const id of chunk) {
+            const data = byId.get(id);
+            if (!data) { out.push(await fetchOneFallback(id)); continue; }
+            out.push({ id, ok: true, status: 200, title: data.title, create_time: data.create_time, update_time: data.update_time, messages: walkMessages(data) });
+          }
+        } catch (err) {
+          for (const id of chunk) out.push({ id, ok: false, status: 0, error: err.message });
+        }
+      }
+      return out;
     })()
   `);
 


### PR DESCRIPTION
## What

Switches the ChatGPT connector from the hard-throttled per-conversation GET to the **bulk `conversations/batch` endpoint** the official iOS/macOS apps use, so history collection no longer stalls on 429s.

Stacked on top of #82 (resumable collection) — base branch is `feat/chatgpt-resume-checkpoint`.

## Why

`GET backend-api/conversation/{id}` is rate-limited to near-zero per account (429, **no** `Retry-After`/rate headers). After moderate use the connector sits at `Saved 0/N — rate limited` indefinitely. Investigation (incl. reverse-engineering `ChatGPT.app`'s `ChatGPT.framework`, which contains `/conversations/batch`, `ConversationBatchRequest`, and *"fetch conversation via remote ID batch fallback"*) showed the apps avoid the wall entirely by fetching in **batches**. Ruled out as the cause along the way: host, cookies, `oai-device-id`, IP, and even a token minted under a non-web `client_id` — all still 429 on the per-id endpoint. The differentiator is the **endpoint**, not identity.

## Change

- `fetchConversationBatch` now does `POST /backend-api/conversations/batch` with `{ "conversation_ids": [ …≤10… ] }`, chunked at 10 (server hard-caps at 10 → `422` above that), and walks each returned conversation's message tree exactly as before.
- **Single-conversation fallback** for any id missing from a batch response (batch occasionally drops an oversized conversation — same "batch fallback" the app does). The fallback uses the old per-id GET and is still throttled, but only fires for rare omissions; a `429` just requeues.
- Per-loop slice size → 10 (one batch call per iteration). All resumable-checkpoint / adaptive-backoff logic from #82 is preserved unchanged.

## Verification

Ran the real connector (dev DataConnect) end-to-end against a 3,774-conversation account:

- **3,773 / 3,774 conversations, 22,366 messages, 0 rate-limit events.**
- The same run on the pre-batch code had been stuck at `Saved 0/3774` for 10+ minutes.
- Batch cap re-confirmed live: 10 → `200`, 11/15 → `422 "conversation_ids must contain at most 10 elements"`.
- The 1 straggler was a batch-omitted conversation → now handled by the new fallback (deferred to the resumable checkpoint).

## Follow-ups before un-drafting

- [x] **Rework `__tests__/chatgpt-resume.browser.test.cjs`** — done (commit e94fd44). The route mock now serves `/conversations/batch` (returns a JSON array, omitting throttled/broken convs so they fall through to the per-id fallback) instead of letting the generic `/conversations` route swallow it. Adds `batchHits` tracking and asserts the batch path is actually exercised (c1–c4 via batch, c5–c12 via omit→fallback→429), while preserving the partial → resume → success + no-redundant-refetch guarantees. (Note: executing it needs a working Chromium; the Playwright-bundled build currently SIGTRAPs on macOS — infra issue, unrelated to this change.)
- [ ] **Regenerate `connector-index.json` + artifact** — this is a **signed, CI/release-pipeline step**, not a manual commit: `connector-index.json` has a top-level `signature`, and a local `generate-connector-index.mjs` run re-hashes **all 18** connector artifacts (local `gtar`/gzip isn't byte-identical to the CI build). `registry.json` is **not** affected by the generator. So: let CI regenerate + re-sign on merge.

### Resilience to server-broken conversations (commit 405abb8)
A conversation can be broken server-side: it returns **HTTP 500** on the batch endpoint, the per-id fallback, **and** on delete (an un-deletable zombie — found a real one in testing: "Digital Art Exploration"). One such conv kept every run stuck at "partial" forever. The connector now skips a conversation after 3 consecutive 5xx (`SERVER_ERROR_MAX_ATTEMPTS`): excluded from `pending`, surfaced as `details.skipped`, so the run classifies **complete**. Network/timeout (status 0) errors are unchanged (retried + deferred). Covered by a new test case (run3).

- [ ] (still open, minor) error summary labels the 5xx as `errorClass: "rate_limited"` — could be its own `server_error` class.
