### PR TITLE
Fix consumer-update bot + Claude display name

### DIFF
--- a/.github/workflows/consumer-update-prs.yml
+++ b/.github/workflows/consumer-update-prs.yml
@@ -16,8 +16,24 @@ permissions:
   contents: read
 
 jobs:
+  preflight:
+    runs-on: ubuntu-latest
+    outputs:
+      has_token: ${{ steps.check.outputs.has_token }}
+    steps:
+      - id: check
+        env:
+          CONSUMER_PR_TOKEN: ${{ secrets.CONSUMER_PR_TOKEN }}
+        run: |
+          if [ -n "$CONSUMER_PR_TOKEN" ]; then
+            echo "has_token=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_token=false" >> "$GITHUB_OUTPUT"
+          fi
+
   update-context-gateway:
-    if: ${{ secrets.CONSUMER_PR_TOKEN != '' }}
+    needs: preflight
+    if: needs.preflight.outputs.has_token == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -67,7 +83,8 @@ jobs:
             - refreshed generated connector catalog
 
   update-data-connect:
-    if: ${{ secrets.CONSUMER_PR_TOKEN != '' }}
+    needs: preflight
+    if: needs.preflight.outputs.has_token == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/connector-index.json
+++ b/connector-index.json
@@ -112,7 +112,7 @@
         "connectorId": "claude-export-playwright",
         "company": "Anthropic",
         "version": "1.0.0",
-        "name": "Claude (Export)",
+        "name": "Claude",
         "status": "experimental",
         "description": "Exports your Claude conversations and projects via Anthropic's official data export (one complete archive, no per-conversation rate limiting).",
         "sourceFiles": {

--- a/registry.json
+++ b/registry.json
@@ -339,7 +339,7 @@
       "id": "claude-export-playwright",
       "company": "Anthropic",
       "version": "1.0.0",
-      "name": "Claude (Export)",
+      "name": "Claude",
       "status": "experimental",
       "description": "Exports your Claude conversations and projects via Anthropic's official data export (one complete archive, no per-conversation rate limiting).",
       "files": {


### PR DESCRIPTION
Two small fixes:

- **CI bot**: `consumer-update-prs.yml` gated both jobs with `if: ${{ secrets.CONSUMER_PR_TOKEN != '' }}`, but the `secrets` context isn't available in job-level `if:` conditions — GitHub failed the whole workflow at parse time (the 0s failures). Replaced with a `preflight` job that reads the token into an output and gates on `needs.preflight.outputs.has_token`. This restores the auto-registration into context-gateway and data-connect for future connectors.
- **Name**: the Claude connector's `name` was still "Claude (Export)" in `registry.json`/index though it displays as "Claude" everywhere. Targeted rename (no artifact rebuild; index check stays green).