### PR TITLE
feat(github): add github.events activity schema (BUI-551 follow-up)

### DIFF
--- a/connectors/github/schemas/github.events.json
+++ b/connectors/github/schemas/github.events.json
@@ -1,0 +1,93 @@
+{
+  "name": "GitHub Activity Events",
+  "version": "1.0.0",
+  "scope": "github.events",
+  "dialect": "json",
+  "description": "Recent public activity (pushes, pull requests, issues, comments, branches, releases, stars, forks) across every repository the user has touched — including organization-owned repos invisible to github.repositories.",
+  "schema": {
+    "type": "object",
+    "properties": {
+      "events": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string"
+            },
+            "createdAt": {
+              "type": "string"
+            },
+            "repo": {
+              "type": "string"
+            },
+            "repoUrl": {
+              "type": "string"
+            },
+            "action": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "title": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "body": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "url": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "branch": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "commits": {
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "isPublic": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "id",
+            "type",
+            "createdAt",
+            "repo",
+            "isPublic"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "fetchedAt": {
+        "type": "string"
+      },
+      "windowDescription": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "events",
+      "fetchedAt"
+    ],
+    "additionalProperties": false
+  }
+}


### PR DESCRIPTION
## `github.events` schema → source of truth in data-connectors

The `github.events` scope (light GitHub activity — commits / PRs / comments rendered on the Memory timeline) is **registered in the data-gateway**, but its `definitionUrl` currently points at a **personal gist** (`gist.githubusercontent.com/volod-vana/…`), which is fragile for team/prod.

This adds the schema to data-connectors alongside the other GitHub schemas (`github.profile`, `github.repositories`, `github.starred`). Content matches the registered definition exactly.

### Follow-up (separate — needs gateway access)
Once this is on `main`, re-register the `github.events` schema with `definitionUrl` pointing at this file's raw URL (`…/data-connectors/main/connectors/github/schemas/github.events.json`). Note: the gateway **409s on a duplicate scope**, so the existing gist-based record must be updated/removed first.

### Context
Part of **BUI-551** (light GitHub activity connector). Consumed by unity-surfaces PR #483.

https://claude.ai/code/session_01TRMw5GuBzfcgvBLfamHG6t